### PR TITLE
lexer&parser: full heredoc/nowdoc support

### DIFF
--- a/meta/dump
+++ b/meta/dump
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -xe
+
+cargo run --bin php-parser-rs -- $1

--- a/meta/snapshot
+++ b/meta/snapshot
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -xe
+
+cargo run --bin snapshot

--- a/src/lexer/byte_string.rs
+++ b/src/lexer/byte_string.rs
@@ -1,6 +1,6 @@
 use std::cmp::{Eq, PartialEq};
 use std::fmt::{Debug, Display, Formatter, Result};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::str::from_utf8;
 
 /// A wrapper for Vec<u8> that provides a human-readable Debug impl and
@@ -95,6 +95,12 @@ impl Deref for ByteString {
 
     fn deref(&self) -> &Vec<u8> {
         &self.0
+    }
+}
+
+impl DerefMut for ByteString {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/src/lexer/error.rs
+++ b/src/lexer/error.rs
@@ -14,6 +14,8 @@ pub enum SyntaxError {
     InvalidOctalLiteral(Span),
     InvalidUnicodeEscape(Span),
     UnpredictableState(Span),
+    InvalidDocIndentation(Span),
+    InvalidDocBodyIndentationLevel(usize, Span),
 }
 
 impl Display for SyntaxError {
@@ -58,6 +60,17 @@ impl Display for SyntaxError {
                 f,
                 "Syntax Error: Reached an unpredictable state on line {} column {}",
                 span.0, span.1
+            ),
+            Self::InvalidDocIndentation(span) => write!(
+                f,
+                "Syntax Error: Invalid indentation - cannot use tabs and spaces on line {}",
+                span.0
+            ),
+            Self::InvalidDocBodyIndentationLevel(expected, span) => write!(
+                f,
+                "Syntax Error: Invalid body indentation level - expecting an indentation level of at least {} on line {}",
+                expected,
+                span.0
             ),
         }
     }

--- a/src/lexer/state.rs
+++ b/src/lexer/state.rs
@@ -5,13 +5,19 @@ use crate::lexer::error::SyntaxResult;
 use crate::lexer::token::Span;
 use crate::prelude::ByteString;
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
+pub enum DocStringKind {
+    Heredoc,
+    Nowdoc,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StackFrame {
     Initial,
     Scripting,
     Halted,
     DoubleQuote,
-    Heredoc(ByteString),
+    DocString(DocStringKind, ByteString),
     LookingForVarname,
     LookingForProperty,
     VarOffset,
@@ -69,6 +75,10 @@ impl State {
 
     pub fn peek_byte(&self, delta: usize) -> Option<u8> {
         self.chars.get(self.cursor + delta).copied()
+    }
+
+    pub fn peek_len(&self, len: usize) -> &[u8] {
+        &self.chars[self.cursor..self.cursor + len]
     }
 
     pub fn try_read(&self, search: &[u8]) -> bool {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -663,6 +663,12 @@ pub enum Expression {
     InterpolatedString {
         parts: Vec<StringPart>,
     },
+    Heredoc {
+        parts: Vec<StringPart>,
+    },
+    Nowdoc {
+        value: ByteString,
+    },
     PropertyFetch {
         target: Box<Self>,
         property: Box<Self>,

--- a/tests/0224/ast.txt
+++ b/tests/0224/ast.txt
@@ -1,0 +1,11 @@
+[
+    Expression {
+        expr: Heredoc {
+            parts: [
+                Const(
+                    "Hello, world!",
+                ),
+            ],
+        },
+    },
+]

--- a/tests/0224/code.php
+++ b/tests/0224/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+Hello, world!
+EOF;

--- a/tests/0224/tokens.txt
+++ b/tests/0224/tokens.txt
@@ -1,0 +1,48 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Heredoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            None,
+            0,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            5,
+            4,
+        ),
+    },
+]

--- a/tests/0225/ast.txt
+++ b/tests/0225/ast.txt
@@ -1,0 +1,11 @@
+[
+    Expression {
+        expr: Heredoc {
+            parts: [
+                Const(
+                    "Hello, world!",
+                ),
+            ],
+        },
+    },
+]

--- a/tests/0225/code.php
+++ b/tests/0225/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<     TXT
+Hello, world!
+TXT;

--- a/tests/0225/tokens.txt
+++ b/tests/0225/tokens.txt
@@ -1,0 +1,48 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "TXT",
+            Heredoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "TXT",
+            None,
+            0,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            5,
+            4,
+        ),
+    },
+]

--- a/tests/0226/code.php
+++ b/tests/0226/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+Hello, world!
+    EOF;

--- a/tests/0226/lexer-error.txt
+++ b/tests/0226/lexer-error.txt
@@ -1,0 +1,1 @@
+InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/0227/code.php
+++ b/tests/0227/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+	Hello, world!
+    EOF;

--- a/tests/0227/lexer-error.txt
+++ b/tests/0227/lexer-error.txt
@@ -1,0 +1,1 @@
+InvalidDocIndentation((5, 1)) -> Syntax Error: Invalid indentation - cannot use tabs and spaces on line 5

--- a/tests/0228/ast.txt
+++ b/tests/0228/ast.txt
@@ -1,0 +1,11 @@
+[
+    Expression {
+        expr: Heredoc {
+            parts: [
+                Const(
+                    "Hello, world!\n",
+                ),
+            ],
+        },
+    },
+]

--- a/tests/0228/code.php
+++ b/tests/0228/code.php
@@ -1,0 +1,6 @@
+<?php
+
+<<<EOF
+Hello, world!
+
+EOF;

--- a/tests/0228/tokens.txt
+++ b/tests/0228/tokens.txt
@@ -1,0 +1,48 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Heredoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "Hello, world!\n",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            None,
+            0,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            6,
+            4,
+        ),
+    },
+]

--- a/tests/0229/ast.txt
+++ b/tests/0229/ast.txt
@@ -1,0 +1,11 @@
+[
+    Expression {
+        expr: Heredoc {
+            parts: [
+                Const(
+                    "Hello, world!",
+                ),
+            ],
+        },
+    },
+]

--- a/tests/0229/code.php
+++ b/tests/0229/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+    Hello, world!
+    EOF;

--- a/tests/0229/tokens.txt
+++ b/tests/0229/tokens.txt
@@ -1,0 +1,50 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Heredoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "    Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            Some(
+                Space,
+            ),
+            4,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            5,
+            8,
+        ),
+    },
+]

--- a/tests/0230/ast.txt
+++ b/tests/0230/ast.txt
@@ -1,0 +1,11 @@
+[
+    Expression {
+        expr: Heredoc {
+            parts: [
+                Const(
+                    "  Hello, world!",
+                ),
+            ],
+        },
+    },
+]

--- a/tests/0230/code.php
+++ b/tests/0230/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+      Hello, world!
+    EOF;

--- a/tests/0230/tokens.txt
+++ b/tests/0230/tokens.txt
@@ -1,0 +1,50 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Heredoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "      Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            Some(
+                Space,
+            ),
+            4,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            5,
+            8,
+        ),
+    },
+]

--- a/tests/0231/ast.txt
+++ b/tests/0231/ast.txt
@@ -1,0 +1,7 @@
+[
+    Expression {
+        expr: Nowdoc {
+            value: "  Hello, world!\n  Hello, world!",
+        },
+    },
+]

--- a/tests/0231/code.php
+++ b/tests/0231/code.php
@@ -1,0 +1,6 @@
+<?php
+
+<<<'EOF'
+  Hello, world!
+  Hello, world!
+EOF;

--- a/tests/0231/tokens.txt
+++ b/tests/0231/tokens.txt
@@ -1,0 +1,48 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Nowdoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "  Hello, world!\n  Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            None,
+            0,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            6,
+            4,
+        ),
+    },
+]

--- a/tests/0232/ast.txt
+++ b/tests/0232/ast.txt
@@ -1,0 +1,7 @@
+[
+    Expression {
+        expr: Nowdoc {
+            value: "Hello, world!\nHello, world!",
+        },
+    },
+]

--- a/tests/0232/code.php
+++ b/tests/0232/code.php
@@ -1,0 +1,6 @@
+<?php
+
+<<<'EOF'
+  Hello, world!
+  Hello, world!
+  EOF;

--- a/tests/0232/tokens.txt
+++ b/tests/0232/tokens.txt
@@ -1,0 +1,50 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Nowdoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "  Hello, world!\n  Hello, world!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            Some(
+                Space,
+            ),
+            2,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            6,
+            6,
+        ),
+    },
+]

--- a/tests/0233/code.php
+++ b/tests/0233/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<EOF
+Hello, world!
+    EOF;

--- a/tests/0233/lexer-error.txt
+++ b/tests/0233/lexer-error.txt
@@ -1,0 +1,1 @@
+InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/0234/code.php
+++ b/tests/0234/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<'EOF'
+Hello, world!
+    EOF;

--- a/tests/0234/lexer-error.txt
+++ b/tests/0234/lexer-error.txt
@@ -1,0 +1,1 @@
+InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/0235/ast.txt
+++ b/tests/0235/ast.txt
@@ -1,0 +1,7 @@
+[
+    Expression {
+        expr: Nowdoc {
+            value: "Hello, {$name}!",
+        },
+    },
+]

--- a/tests/0235/code.php
+++ b/tests/0235/code.php
@@ -1,0 +1,5 @@
+<?php
+
+<<<'EOF'
+Hello, {$name}!
+EOF;

--- a/tests/0235/tokens.txt
+++ b/tests/0235/tokens.txt
@@ -1,0 +1,48 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: StartDocString(
+            "EOF",
+            Nowdoc,
+        ),
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: StringPart(
+            "Hello, {$name}!",
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: EndDocString(
+            "EOF",
+            None,
+            0,
+        ),
+        span: (
+            4,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            5,
+            4,
+        ),
+    },
+]


### PR DESCRIPTION
Closes #22.

There's a few FIXMEs in here, because it's late and I just wanted to get it all working. Will come back on a FIXME roulette later and sort those out.

Noteworthy additions in this PR are the `meta/snapshot` and `meta/dump` scripts. Shorthands for running the `snapshot` binary and `php-parser-rs` binary, saves some typing.