### PR TITLE
fix: attributes support

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -69,7 +69,7 @@ impl Lexer {
                     let label = label.clone();
 
                     tokens.extend(self.heredoc(&mut state, label)?)
-                },
+                }
                 // LookingForProperty is entered inside double quotes,
                 // backticks, or a heredoc, expecting a variable name.
                 // If one isn't found, it switches to scripting.
@@ -520,14 +520,17 @@ impl Lexer {
                     None => unreachable!(),
                 };
 
-                if ! matches!(state.peek_buf(), [b'\n', ..]) {
-                    return Err(SyntaxError::UnexpectedCharacter(state.current.unwrap(), state.span));
+                if !matches!(state.peek_buf(), [b'\n', ..]) {
+                    return Err(SyntaxError::UnexpectedCharacter(
+                        state.current.unwrap(),
+                        state.span,
+                    ));
                 }
 
                 state.next();
-                state.set(StackFrame::Heredoc(label.clone().into()))?;
+                state.set(StackFrame::Heredoc(label.clone()))?;
 
-                TokenKind::StartHeredoc(label.into())
+                TokenKind::StartHeredoc(label)
             }
             [b'<', b'<', b'=', ..] => {
                 state.skip(3);
@@ -704,7 +707,7 @@ impl Lexer {
                     if matches!(buffer.last(), Some(b'\n')) && state.try_read(&label.0) {
                         state.skip(label.len());
                         state.set(StackFrame::Scripting)?;
-                        break TokenKind::EndHeredoc(label.clone());
+                        break TokenKind::EndHeredoc(label);
                     }
 
                     state.next();

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -212,12 +212,8 @@ impl Default for Token {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Self::StartHeredoc(label) => {
-                return write!(f, "<<<{}", label)
-            },
-            Self::EndHeredoc(label) => {
-                return write!(f, "{}", label)
-            },
+            Self::StartHeredoc(label) => return write!(f, "<<<{}", label),
+            Self::EndHeredoc(label) => return write!(f, "{}", label),
             Self::BangEquals => "!=",
             Self::From => "from",
             Self::Print => "print",

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use crate::lexer::byte_string::ByteString;
+use crate::lexer::token::Span;
 use crate::lexer::token::TokenKind;
 
 pub type Block = Vec<Statement>;
@@ -143,6 +144,7 @@ pub type ParamList = Vec<Param>;
 #[derive(Debug, PartialEq, Clone)]
 pub struct Param {
     pub name: Expression,
+    pub attributes: Vec<Attribute>,
     pub r#type: Option<Type>,
     pub variadic: bool,
     pub default: Option<Expression>,
@@ -154,6 +156,7 @@ impl From<ByteString> for Param {
     fn from(name: ByteString) -> Self {
         Self {
             name: Expression::Variable { name },
+            attributes: vec![],
             r#type: None,
             variadic: false,
             default: None,
@@ -305,6 +308,12 @@ pub enum TraitAdaptation {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub struct Attribute {
+    pub span: Span,
+    pub expression: Expression,
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub enum Statement {
     InlineHtml(ByteString),
     Goto {
@@ -346,11 +355,13 @@ pub enum Statement {
     },
     Var {
         var: ByteString,
+        attributes: Vec<Attribute>,
         value: Option<Expression>,
         r#type: Option<Type>,
     },
     Property {
         var: ByteString,
+        attributes: Vec<Attribute>,
         value: Option<Expression>,
         r#type: Option<Type>,
         flags: Vec<PropertyFlag>,
@@ -365,6 +376,7 @@ pub enum Statement {
     },
     Function {
         name: Identifier,
+        attributes: Vec<Attribute>,
         params: Vec<Param>,
         body: Block,
         return_type: Option<Type>,
@@ -372,6 +384,7 @@ pub enum Statement {
     },
     Class {
         name: Identifier,
+        attributes: Vec<Attribute>,
         extends: Option<Identifier>,
         implements: Vec<Identifier>,
         body: Block,
@@ -379,6 +392,7 @@ pub enum Statement {
     },
     Trait {
         name: Identifier,
+        attributes: Vec<Attribute>,
         body: Block,
     },
     TraitUse {
@@ -387,11 +401,13 @@ pub enum Statement {
     },
     Interface {
         name: Identifier,
+        attributes: Vec<Attribute>,
         extends: Vec<Identifier>,
         body: Block,
     },
     Method {
         name: Identifier,
+        attributes: Vec<Attribute>,
         params: Vec<Param>,
         body: Block,
         flags: Vec<MethodFlag>,
@@ -400,6 +416,7 @@ pub enum Statement {
     },
     AbstractMethod {
         name: Identifier,
+        attributes: Vec<Attribute>,
         params: Vec<Param>,
         flags: Vec<MethodFlag>,
         return_type: Option<Type>,
@@ -457,11 +474,13 @@ pub enum Statement {
     },
     UnitEnum {
         name: Identifier,
+        attributes: Vec<Attribute>,
         implements: Vec<Identifier>,
         body: Block,
     },
     BackedEnum {
         name: Identifier,
+        attributes: Vec<Attribute>,
         implements: Vec<Identifier>,
         backed_type: BackedEnumType,
         body: Block,
@@ -619,6 +638,7 @@ pub enum Expression {
     },
     Closure {
         params: Vec<Param>,
+        attributes: Vec<Attribute>,
         uses: Vec<ClosureUse>,
         return_type: Option<Type>,
         body: Block,
@@ -627,6 +647,7 @@ pub enum Expression {
     },
     ArrowFunction {
         params: Vec<Param>,
+        attributes: Vec<Attribute>,
         return_type: Option<Type>,
         expr: Box<Self>,
         by_ref: bool,
@@ -674,6 +695,7 @@ pub enum Expression {
         args: Vec<Arg>,
     },
     AnonymousClass {
+        attributes: Vec<Attribute>,
         extends: Option<Identifier>,
         implements: Vec<Identifier>,
         body: Block,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -35,6 +35,7 @@ pub enum ParseError {
     ForbiddenTypeUsedInProperty(String, String, Type, Span),
     MatchExpressionWithMultipleDefaultArms(Span),
     CannotFindTypeInCurrentScope(String, Span),
+    ExpectedItemDefinitionAfterAttributes(Span),
 }
 
 impl Display for ParseError {
@@ -82,6 +83,7 @@ impl Display for ParseError {
             Self::ForbiddenTypeUsedInProperty(class, prop, ty, span) => write!(f, "Parse Error: Property {}::${} cannot have type `{}` on line {} column {}", class, prop, ty, span.0, span.1),
             Self::MatchExpressionWithMultipleDefaultArms(span) => write!(f, "Parse Error: Match expressions may only contain one default arm on line {} column {}", span.0, span.1),
             Self::CannotFindTypeInCurrentScope(ty, span) => write!(f, "Parse Error: Cannot find type `{}` in this scope on line {} on column {}", ty, span.0, span.1),
+            Self::ExpectedItemDefinitionAfterAttributes(span) => write!(f, "Parse Error: Expected item definition after attribute on line {} column {}", span.0, span.1),
         }
     }
 }

--- a/src/parser/internal/attributes.rs
+++ b/src/parser/internal/attributes.rs
@@ -1,0 +1,36 @@
+use crate::lexer::token::TokenKind;
+use crate::parser::ast::Attribute;
+use crate::parser::error::ParseResult;
+use crate::parser::internal::precedence::Precedence;
+use crate::parser::state::State;
+use crate::parser::Parser;
+
+impl Parser {
+    pub(in crate::parser) fn gather_attributes(&self, state: &mut State) -> ParseResult<bool> {
+        state.gather_comments();
+
+        if state.current.kind != TokenKind::Attribute {
+            return Ok(false);
+        }
+
+        state.next();
+
+        while state.current.kind != TokenKind::RightBracket {
+            let span = state.current.span;
+            let expression = self.expression(state, Precedence::Lowest)?;
+
+            state.attribute(Attribute { span, expression });
+
+            if state.current.kind == TokenKind::Comma {
+                state.next();
+            } else {
+                break;
+            }
+        }
+
+        self.rbracket(state)?;
+
+        // recursive, looking for multiple attribute brackets after each other.
+        self.gather_attributes(state).map(|_| true)
+    }
+}

--- a/src/parser/internal/classish.rs
+++ b/src/parser/internal/classish.rs
@@ -46,6 +46,8 @@ impl Parser {
 
                 self.lbrace(state)?;
 
+                let attributes = state.get_attributes();
+
                 let mut body = Vec::new();
                 while state.current.kind != TokenKind::RightBrace {
                     state.gather_comments();
@@ -61,6 +63,7 @@ impl Parser {
 
                 Ok(Statement::Class {
                     name: name.into(),
+                    attributes,
                     extends,
                     implements,
                     body,
@@ -90,6 +93,8 @@ impl Parser {
 
             self.lbrace(state)?;
 
+            let attributes = state.get_attributes();
+
             let mut body = Vec::new();
             while state.current.kind != TokenKind::RightBrace && !state.is_eof() {
                 state.gather_comments();
@@ -105,6 +110,7 @@ impl Parser {
 
             Ok(Statement::Interface {
                 name: name.into(),
+                attributes,
                 extends,
                 body,
             })
@@ -118,6 +124,8 @@ impl Parser {
 
         scoped!(state, Scope::Trait(name.clone()), {
             self.lbrace(state)?;
+
+            let attributes = state.get_attributes();
 
             let mut body = Vec::new();
             while state.current.kind != TokenKind::RightBrace && !state.is_eof() {
@@ -134,6 +142,7 @@ impl Parser {
 
             Ok(Statement::Trait {
                 name: name.into(),
+                attributes,
                 body,
             })
         })
@@ -144,6 +153,9 @@ impl Parser {
         state: &mut State,
     ) -> ParseResult<Expression> {
         expect_token!([TokenKind::New], state, ["`new`"]);
+
+        self.gather_attributes(state)?;
+
         expect_token!([TokenKind::Class], state, ["`class`"]);
 
         let mut args = vec![];
@@ -179,6 +191,8 @@ impl Parser {
 
             self.lbrace(state)?;
 
+            let attributes = state.get_attributes();
+
             let mut body = Vec::new();
             while state.current.kind != TokenKind::RightBrace && !state.is_eof() {
                 body.push(self.class_like_statement(state)?);
@@ -188,6 +202,7 @@ impl Parser {
 
             Ok(Expression::New {
                 target: Box::new(Expression::AnonymousClass {
+                    attributes,
                     extends,
                     implements,
                     body,
@@ -234,6 +249,8 @@ impl Parser {
                 }
             }
 
+            let attributes = state.get_attributes();
+
             self.lbrace(state)?;
 
             let mut body = Block::new();
@@ -247,12 +264,14 @@ impl Parser {
             match backed_type {
                 Some(backed_type) => Ok(Statement::BackedEnum {
                     name: name.into(),
+                    attributes,
                     backed_type,
                     implements,
                     body,
                 }),
                 None => Ok(Statement::UnitEnum {
                     name: name.into(),
+                    attributes,
                     implements,
                     body,
                 }),

--- a/src/parser/internal/mod.rs
+++ b/src/parser/internal/mod.rs
@@ -1,3 +1,4 @@
+pub mod attributes;
 pub mod block;
 pub mod classish;
 pub mod classish_statement;

--- a/src/parser/internal/params.rs
+++ b/src/parser/internal/params.rs
@@ -55,6 +55,8 @@ impl Parser {
         self.lparen(state)?;
 
         while !state.is_eof() && state.current.kind != TokenKind::RightParen {
+            self.gather_attributes(state)?;
+
             let flags: Vec<PropertyFlag> = self
                 .promoted_property_flags(state)?
                 .iter()
@@ -131,6 +133,7 @@ impl Parser {
 
             params.push(Param {
                 name: Expression::Variable { name: var },
+                attributes: state.get_attributes(),
                 r#type: ty,
                 variadic,
                 default,

--- a/src/parser/state.rs
+++ b/src/parser/state.rs
@@ -4,6 +4,7 @@ use std::vec::IntoIter;
 use crate::lexer::byte_string::ByteString;
 use crate::lexer::token::Token;
 use crate::lexer::token::TokenKind;
+use crate::parser::ast::Attribute;
 use crate::parser::ast::ClassFlag;
 use crate::parser::ast::MethodFlag;
 use crate::parser::error::ParseError;
@@ -39,6 +40,7 @@ pub struct State {
     pub peek: Token,
     pub iter: IntoIter<Token>,
     pub comments: Vec<Token>,
+    pub attributes: Vec<Attribute>,
     pub namespace_type: Option<NamespaceType>,
     pub has_class_scope: bool,
     pub has_class_parent_scope: bool,
@@ -57,7 +59,20 @@ impl State {
             namespace_type: None,
             has_class_scope: false,
             has_class_parent_scope: false,
+            attributes: vec![],
         }
+    }
+
+    pub fn attribute(&mut self, attr: Attribute) {
+        self.attributes.push(attr);
+    }
+
+    pub fn get_attributes(&mut self) -> Vec<Attribute> {
+        let mut attributes = vec![];
+
+        std::mem::swap(&mut self.attributes, &mut attributes);
+
+        attributes
     }
 
     /// Return the namespace type used in the current state
@@ -145,9 +160,11 @@ impl State {
     }
 
     pub fn clear_comments(&mut self) -> Vec<Token> {
-        let c = self.comments.clone();
-        self.comments = vec![];
-        c
+        let mut comments = vec![];
+
+        std::mem::swap(&mut self.comments, &mut comments);
+
+        comments
     }
 
     pub fn is_eof(&mut self) -> bool {

--- a/tests/0001/ast.txt
+++ b/tests/0001/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "a",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),
@@ -24,6 +26,7 @@
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Array,
                 ),
@@ -64,11 +67,13 @@
         name: Identifier {
             name: "bar",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "a",
                 },
+                attributes: [],
                 type: Some(
                     Integer,
                 ),
@@ -81,6 +86,7 @@
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Float,
                 ),
@@ -93,6 +99,7 @@
                 name: Variable {
                     name: "c",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),
@@ -105,6 +112,7 @@
                 name: Variable {
                     name: "d",
                 },
+                attributes: [],
                 type: Some(
                     True,
                 ),
@@ -117,6 +125,7 @@
                 name: Variable {
                     name: "e",
                 },
+                attributes: [],
                 type: Some(
                     False,
                 ),
@@ -129,6 +138,7 @@
                 name: Variable {
                     name: "f",
                 },
+                attributes: [],
                 type: Some(
                     Null,
                 ),

--- a/tests/0014/ast.txt
+++ b/tests/0014/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo2",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -34,6 +35,7 @@
         name: Identifier {
             name: "Bar2",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -71,6 +73,7 @@
         name: Identifier {
             name: "Bar3",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -104,6 +107,7 @@
         name: Identifier {
             name: "Bar4",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [

--- a/tests/0018/ast.txt
+++ b/tests/0018/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "a",
         },
+        attributes: [],
         params: [],
         body: [
             Echo {

--- a/tests/0019/ast.txt
+++ b/tests/0019/ast.txt
@@ -6,6 +6,7 @@
                 name: Identifier {
                     name: "globalFunc",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,
@@ -26,6 +27,7 @@
                     op: Assign,
                     rhs: Closure {
                         params: [],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -46,6 +48,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -53,6 +56,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -69,6 +73,7 @@
                     op: Assign,
                     rhs: Closure {
                         params: [],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -89,6 +94,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -96,6 +102,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [
@@ -120,6 +127,7 @@
                     op: Assign,
                     rhs: ArrowFunction {
                         params: [],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: false,
@@ -139,6 +147,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -146,6 +155,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: false,
@@ -161,6 +171,7 @@
                     op: Assign,
                     rhs: ArrowFunction {
                         params: [],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: true,
@@ -180,6 +191,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -187,6 +199,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         return_type: None,
                         expr: Variable {
                             name: "b",
@@ -211,6 +224,7 @@
                     op: Assign,
                     rhs: Closure {
                         params: [],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -231,6 +245,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -238,6 +253,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -254,6 +270,7 @@
                     op: Assign,
                     rhs: Closure {
                         params: [],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [],
@@ -274,6 +291,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -281,6 +299,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         uses: [],
                         return_type: None,
                         body: [
@@ -305,6 +324,7 @@
                     op: Assign,
                     rhs: ArrowFunction {
                         params: [],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: false,
@@ -324,6 +344,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -331,6 +352,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: false,
@@ -346,6 +368,7 @@
                     op: Assign,
                     rhs: ArrowFunction {
                         params: [],
+                        attributes: [],
                         return_type: None,
                         expr: Null,
                         by_ref: true,
@@ -365,6 +388,7 @@
                                 name: Variable {
                                     name: "b",
                                 },
+                                attributes: [],
                                 type: None,
                                 variadic: false,
                                 default: None,
@@ -372,6 +396,7 @@
                                 by_ref: true,
                             },
                         ],
+                        attributes: [],
                         return_type: None,
                         expr: Variable {
                             name: "b",
@@ -392,11 +417,13 @@
                 name: Identifier {
                     name: "a",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "b",
                         },
+                        attributes: [],
                         type: None,
                         variadic: false,
                         default: None,
@@ -412,11 +439,13 @@
                 name: Identifier {
                     name: "b",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "b",
                         },
+                        attributes: [],
                         type: None,
                         variadic: false,
                         default: None,
@@ -440,6 +469,7 @@
                 name: Identifier {
                     name: "c",
                 },
+                attributes: [],
                 params: [],
                 body: [
                     Return {

--- a/tests/0035/ast.txt
+++ b/tests/0035/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: None,

--- a/tests/0036/ast.txt
+++ b/tests/0036/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "n",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,

--- a/tests/0037/ast.txt
+++ b/tests/0037/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "n",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,
@@ -18,6 +20,7 @@
                 name: Variable {
                     name: "m",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,

--- a/tests/0038/ast.txt
+++ b/tests/0038/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "fib",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "n",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,

--- a/tests/0043/ast.txt
+++ b/tests/0043/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [],

--- a/tests/0045/ast.txt
+++ b/tests/0045/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -10,6 +11,7 @@
                 name: Identifier {
                     name: "bar",
                 },
+                attributes: [],
                 params: [],
                 body: [
                     Echo {

--- a/tests/0046/ast.txt
+++ b/tests/0046/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         extends: Some(
             Identifier {
                 name: "Bar",

--- a/tests/0047/ast.txt
+++ b/tests/0047/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         extends: None,
         implements: [
             Identifier {

--- a/tests/0048/ast.txt
+++ b/tests/0048/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),

--- a/tests/0049/ast.txt
+++ b/tests/0049/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Union(
                         [

--- a/tests/0050/ast.txt
+++ b/tests/0050/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "bar",
                 },
+                attributes: [],
                 type: None,
                 variadic: true,
                 default: None,

--- a/tests/0051/ast.txt
+++ b/tests/0051/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "bar",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),

--- a/tests/0052/ast.txt
+++ b/tests/0052/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "bar",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,
@@ -18,6 +20,7 @@
                 name: Variable {
                     name: "baz",
                 },
+                attributes: [],
                 type: None,
                 variadic: false,
                 default: None,
@@ -28,6 +31,7 @@
                 name: Variable {
                     name: "car",
                 },
+                attributes: [],
                 type: None,
                 variadic: true,
                 default: None,

--- a/tests/0053/ast.txt
+++ b/tests/0053/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Nullable(
                         String,

--- a/tests/0054/ast.txt
+++ b/tests/0054/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Union(
                         [

--- a/tests/0055/ast.txt
+++ b/tests/0055/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Union(
                         [

--- a/tests/0056/ast.txt
+++ b/tests/0056/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Intersection(
                         [

--- a/tests/0057/ast.txt
+++ b/tests/0057/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "b",
                 },
+                attributes: [],
                 type: Some(
                     Intersection(
                         [

--- a/tests/0058/ast.txt
+++ b/tests/0058/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: Some(

--- a/tests/0059/ast.txt
+++ b/tests/0059/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: Some(

--- a/tests/0060/ast.txt
+++ b/tests/0060/ast.txt
@@ -2,6 +2,7 @@
     Expression {
         expr: New {
             target: AnonymousClass {
+                attributes: [],
                 extends: None,
                 implements: [],
                 body: [],

--- a/tests/0061/ast.txt
+++ b/tests/0061/ast.txt
@@ -2,6 +2,7 @@
     Expression {
         expr: New {
             target: AnonymousClass {
+                attributes: [],
                 extends: None,
                 implements: [],
                 body: [],

--- a/tests/0062/ast.txt
+++ b/tests/0062/ast.txt
@@ -2,6 +2,7 @@
     Expression {
         expr: New {
             target: AnonymousClass {
+                attributes: [],
                 extends: Some(
                     Identifier {
                         name: "Foo",

--- a/tests/0063/ast.txt
+++ b/tests/0063/ast.txt
@@ -2,6 +2,7 @@
     Expression {
         expr: New {
             target: AnonymousClass {
+                attributes: [],
                 extends: None,
                 implements: [
                     Identifier {

--- a/tests/0064/ast.txt
+++ b/tests/0064/ast.txt
@@ -2,6 +2,7 @@
     Expression {
         expr: New {
             target: AnonymousClass {
+                attributes: [],
                 extends: None,
                 implements: [],
                 body: [
@@ -9,6 +10,7 @@
                         name: Identifier {
                             name: "foo",
                         },
+                        attributes: [],
                         params: [],
                         body: [],
                         flags: [

--- a/tests/0068/ast.txt
+++ b/tests/0068/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "MyClass",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
             Property {
                 var: "a",
+                attributes: [],
                 value: None,
                 type: None,
                 flags: [

--- a/tests/0085/ast.txt
+++ b/tests/0085/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [],

--- a/tests/0091/ast.txt
+++ b/tests/0091/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "a",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: Some(

--- a/tests/0092/ast.txt
+++ b/tests/0092/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "a",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: Some(

--- a/tests/0109/ast.txt
+++ b/tests/0109/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -10,11 +11,13 @@
                 name: Identifier {
                     name: "__construct",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "a",
                         },
+                        attributes: [],
                         type: Some(
                             String,
                         ),
@@ -29,6 +32,7 @@
                         name: Variable {
                             name: "b",
                         },
+                        attributes: [],
                         type: Some(
                             Integer,
                         ),
@@ -44,6 +48,7 @@
                         name: Variable {
                             name: "c",
                         },
+                        attributes: [],
                         type: Some(
                             Float,
                         ),
@@ -59,6 +64,7 @@
                         name: Variable {
                             name: "e",
                         },
+                        attributes: [],
                         type: None,
                         variadic: true,
                         default: None,

--- a/tests/0110/ast.txt
+++ b/tests/0110/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -10,11 +11,13 @@
                 name: Identifier {
                     name: "__construct",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "a",
                         },
+                        attributes: [],
                         type: Some(
                             String,
                         ),
@@ -29,6 +32,7 @@
                         name: Variable {
                             name: "b",
                         },
+                        attributes: [],
                         type: Some(
                             Integer,
                         ),
@@ -44,6 +48,7 @@
                         name: Variable {
                             name: "c",
                         },
+                        attributes: [],
                         type: Some(
                             Float,
                         ),
@@ -59,6 +64,7 @@
                         name: Variable {
                             name: "e",
                         },
+                        attributes: [],
                         type: None,
                         variadic: true,
                         default: None,

--- a/tests/0117/ast.txt
+++ b/tests/0117/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         implements: [],
         backed_type: Int,
         body: [

--- a/tests/0118/ast.txt
+++ b/tests/0118/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         implements: [],
         body: [
             UnitEnumCase {

--- a/tests/0119/ast.txt
+++ b/tests/0119/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "Foo",
         },
+        attributes: [],
         implements: [],
         backed_type: String,
         body: [

--- a/tests/0127/ast.txt
+++ b/tests/0127/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -10,11 +11,13 @@
                 name: Identifier {
                     name: "__construct",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "s",
                         },
+                        attributes: [],
                         type: Some(
                             String,
                         ),

--- a/tests/0130/ast.txt
+++ b/tests/0130/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [
@@ -10,6 +11,7 @@
                 name: Identifier {
                     name: "foreach",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 flags: [

--- a/tests/0143/ast.txt
+++ b/tests/0143/ast.txt
@@ -3,12 +3,14 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: [],
         body: [
             AbstractMethod {
                 name: Identifier {
                     name: "bar",
                 },
+                attributes: [],
                 params: [],
                 flags: [
                     Public,

--- a/tests/0145/ast.txt
+++ b/tests/0145/ast.txt
@@ -3,12 +3,14 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: [],
         body: [
             AbstractMethod {
                 name: Identifier {
                     name: "bar",
                 },
+                attributes: [],
                 params: [],
                 flags: [
                     Public,

--- a/tests/0153/ast.txt
+++ b/tests/0153/ast.txt
@@ -7,6 +7,7 @@
                 name: Identifier {
                     name: "Baz",
                 },
+                attributes: [],
                 extends: None,
                 implements: [],
                 body: [
@@ -14,11 +15,13 @@
                         name: Identifier {
                             name: "__construct",
                         },
+                        attributes: [],
                         params: [
                             Param {
                                 name: Variable {
                                     name: "name",
                                 },
+                                attributes: [],
                                 type: Some(
                                     String,
                                 ),

--- a/tests/0155/ast.txt
+++ b/tests/0155/ast.txt
@@ -7,11 +7,13 @@
                 name: Identifier {
                     name: "Baz",
                 },
+                attributes: [],
                 extends: None,
                 implements: [],
                 body: [
                     Property {
                         var: "foo",
+                        attributes: [],
                         value: None,
                         type: Some(
                             String,

--- a/tests/0157/ast.txt
+++ b/tests/0157/ast.txt
@@ -8,6 +8,7 @@
                 name: Identifier {
                     name: "foo",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,

--- a/tests/0158/ast.txt
+++ b/tests/0158/ast.txt
@@ -7,6 +7,7 @@
                 name: Identifier {
                     name: "foo",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,
@@ -22,6 +23,7 @@
                 name: Identifier {
                     name: "foo",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,

--- a/tests/0164/ast.txt
+++ b/tests/0164/ast.txt
@@ -6,6 +6,7 @@
                 name: Identifier {
                     name: "foo",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,
@@ -22,6 +23,7 @@
                 name: Identifier {
                     name: "foo",
                 },
+                attributes: [],
                 params: [],
                 body: [],
                 return_type: None,

--- a/tests/0176/ast.txt
+++ b/tests/0176/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "a",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),
@@ -20,6 +22,7 @@
                 name: Variable {
                     name: "bar",
                 },
+                attributes: [],
                 type: Some(
                     Integer,
                 ),
@@ -32,6 +35,7 @@
                 name: Variable {
                     name: "baz",
                 },
+                attributes: [],
                 type: Some(
                     Float,
                 ),

--- a/tests/0177/ast.txt
+++ b/tests/0177/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "a",
                 },
+                attributes: [],
                 type: Some(
                     String,
                 ),
@@ -20,6 +22,7 @@
                 name: Variable {
                     name: "bar",
                 },
+                attributes: [],
                 type: Some(
                     Integer,
                 ),
@@ -32,6 +35,7 @@
                 name: Variable {
                     name: "baz",
                 },
+                attributes: [],
                 type: Some(
                     Float,
                 ),

--- a/tests/0178/ast.txt
+++ b/tests/0178/ast.txt
@@ -64,11 +64,13 @@
                 name: Identifier {
                     name: "box",
                 },
+                attributes: [],
                 params: [
                     Param {
                         name: Variable {
                             name: "fun",
                         },
+                        attributes: [],
                         type: Some(
                             Identifier(
                                 Identifier {
@@ -106,6 +108,7 @@
                                                 name: Variable {
                                                     name: "_type",
                                                 },
+                                                attributes: [],
                                                 type: Some(
                                                     Integer,
                                                 ),
@@ -118,6 +121,7 @@
                                                 name: Variable {
                                                     name: "message",
                                                 },
+                                                attributes: [],
                                                 type: Some(
                                                     String,
                                                 ),
@@ -127,6 +131,7 @@
                                                 by_ref: false,
                                             },
                                         ],
+                                        attributes: [],
                                         uses: [
                                             ClosureUse {
                                                 var: Variable {

--- a/tests/0189/ast.txt
+++ b/tests/0189/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [],
         body: [
             Global {

--- a/tests/0190/ast.txt
+++ b/tests/0190/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [],
         body: [
             Static {

--- a/tests/0201/ast.txt
+++ b/tests/0201/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "A",
         },
+        attributes: [],
         extends: None,
         implements: [
             Identifier {

--- a/tests/0203/ast.txt
+++ b/tests/0203/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "A",
         },
+        attributes: [],
         implements: [
             Identifier {
                 name: "B",

--- a/tests/0204/ast.txt
+++ b/tests/0204/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [

--- a/tests/0205/ast.txt
+++ b/tests/0205/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [

--- a/tests/0207/ast.txt
+++ b/tests/0207/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [

--- a/tests/0215/ast.txt
+++ b/tests/0215/ast.txt
@@ -3,11 +3,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         body: [
             Method {
                 name: Identifier {
                     name: "bar",
                 },
+                attributes: [],
                 params: [],
                 body: [
                     Expression {

--- a/tests/0217/ast.txt
+++ b/tests/0217/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "s",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [],
@@ -12,6 +13,7 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         extends: Some(
             Identifier {
                 name: "s",
@@ -23,6 +25,7 @@
                 name: Identifier {
                     name: "bar",
                 },
+                attributes: [],
                 params: [],
                 body: [
                     Return {

--- a/tests/0220/ast.txt
+++ b/tests/0220/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "bar",
         },
+        attributes: [],
         extends: None,
         implements: [],
         body: [],
@@ -17,6 +18,7 @@
             op: Assign,
             rhs: New {
                 target: AnonymousClass {
+                    attributes: [],
                     extends: Some(
                         Identifier {
                             name: "bar",
@@ -28,6 +30,7 @@
                             name: Identifier {
                                 name: "bar",
                             },
+                            attributes: [],
                             params: [],
                             body: [
                                 Return {

--- a/tests/0221/ast.txt
+++ b/tests/0221/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "A",
         },
+        attributes: [],
         extends: [],
         body: [],
     },
@@ -10,6 +11,7 @@
         name: Identifier {
             name: "B",
         },
+        attributes: [],
         extends: [],
         body: [],
     },
@@ -17,6 +19,7 @@
         name: Identifier {
             name: "C",
         },
+        attributes: [],
         extends: [],
         body: [],
     },
@@ -24,6 +27,7 @@
         name: Identifier {
             name: "D",
         },
+        attributes: [],
         extends: [],
         body: [],
     },
@@ -31,11 +35,13 @@
         name: Identifier {
             name: "foo",
         },
+        attributes: [],
         params: [
             Param {
                 name: Variable {
                     name: "a",
                 },
+                attributes: [],
                 type: Some(
                     Union(
                         [

--- a/tests/0222/ast.txt
+++ b/tests/0222/ast.txt
@@ -3,6 +3,7 @@
         name: Identifier {
             name: "null",
         },
+        attributes: [],
         params: [],
         body: [],
         return_type: None,

--- a/tests/0223/ast.txt
+++ b/tests/0223/ast.txt
@@ -1,0 +1,561 @@
+[
+    Function {
+        name: Identifier {
+            name: "a",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    4,
+                    5,
+                ),
+                expression: Identifier {
+                    name: "A1",
+                },
+            },
+            Attribute {
+                span: (
+                    5,
+                    5,
+                ),
+                expression: Call {
+                    target: Identifier {
+                        name: "A2",
+                    },
+                    args: [],
+                },
+            },
+            Attribute {
+                span: (
+                    6,
+                    5,
+                ),
+                expression: Call {
+                    target: Identifier {
+                        name: "A3",
+                    },
+                    args: [
+                        Arg {
+                            name: None,
+                            value: LiteralInteger {
+                                i: 0,
+                            },
+                            unpack: false,
+                        },
+                    ],
+                },
+            },
+            Attribute {
+                span: (
+                    7,
+                    5,
+                ),
+                expression: Call {
+                    target: Identifier {
+                        name: "A4",
+                    },
+                    args: [
+                        Arg {
+                            name: Some(
+                                "x",
+                            ),
+                            value: LiteralInteger {
+                                i: 1,
+                            },
+                            unpack: false,
+                        },
+                    ],
+                },
+            },
+        ],
+        params: [
+            Param {
+                name: Variable {
+                    name: "a",
+                },
+                attributes: [
+                    Attribute {
+                        span: (
+                            10,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A5",
+                        },
+                    },
+                ],
+                type: Some(
+                    Union(
+                        [
+                            Integer,
+                            Float,
+                        ],
+                    ),
+                ),
+                variadic: false,
+                default: None,
+                flags: [],
+                by_ref: false,
+            },
+            Param {
+                name: Variable {
+                    name: "c",
+                },
+                attributes: [
+                    Attribute {
+                        span: (
+                            12,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A6",
+                        },
+                    },
+                ],
+                type: None,
+                variadic: false,
+                default: None,
+                flags: [],
+                by_ref: false,
+            },
+            Param {
+                name: Variable {
+                    name: "b",
+                },
+                attributes: [
+                    Attribute {
+                        span: (
+                            14,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A7",
+                        },
+                    },
+                ],
+                type: Some(
+                    String,
+                ),
+                variadic: false,
+                default: None,
+                flags: [],
+                by_ref: false,
+            },
+        ],
+        body: [],
+        return_type: None,
+        by_ref: false,
+    },
+    Class {
+        name: Identifier {
+            name: "C",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    19,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A8",
+                },
+            },
+            Attribute {
+                span: (
+                    19,
+                    7,
+                ),
+                expression: Call {
+                    target: Identifier {
+                        name: "A9",
+                    },
+                    args: [],
+                },
+            },
+            Attribute {
+                span: (
+                    19,
+                    13,
+                ),
+                expression: Call {
+                    target: Identifier {
+                        name: "A10",
+                    },
+                    args: [
+                        Arg {
+                            name: Some(
+                                "foo",
+                            ),
+                            value: Identifier {
+                                name: "bar",
+                            },
+                            unpack: false,
+                        },
+                    ],
+                },
+            },
+        ],
+        extends: None,
+        implements: [],
+        body: [
+            Method {
+                name: Identifier {
+                    name: "__construct",
+                },
+                attributes: [
+                    Attribute {
+                        span: (
+                            21,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A11",
+                        },
+                    },
+                ],
+                params: [
+                    Param {
+                        name: Variable {
+                            name: "s",
+                        },
+                        attributes: [
+                            Attribute {
+                                span: (
+                                    23,
+                                    11,
+                                ),
+                                expression: Identifier {
+                                    name: "A12",
+                                },
+                            },
+                        ],
+                        type: Some(
+                            String,
+                        ),
+                        variadic: false,
+                        default: None,
+                        flags: [
+                            Public,
+                            Readonly,
+                        ],
+                        by_ref: false,
+                    },
+                ],
+                body: [],
+                flags: [
+                    Public,
+                ],
+                return_type: None,
+                by_ref: false,
+            },
+            Method {
+                name: Identifier {
+                    name: "m",
+                },
+                attributes: [
+                    Attribute {
+                        span: (
+                            27,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A13",
+                        },
+                    },
+                ],
+                params: [
+                    Param {
+                        name: Variable {
+                            name: "param",
+                        },
+                        attributes: [
+                            Attribute {
+                                span: (
+                                    29,
+                                    11,
+                                ),
+                                expression: Identifier {
+                                    name: "A14",
+                                },
+                            },
+                        ],
+                        type: None,
+                        variadic: false,
+                        default: None,
+                        flags: [],
+                        by_ref: false,
+                    },
+                ],
+                body: [],
+                flags: [
+                    Public,
+                ],
+                return_type: None,
+                by_ref: false,
+            },
+            Property {
+                var: "prop",
+                attributes: [
+                    Attribute {
+                        span: (
+                            32,
+                            7,
+                        ),
+                        expression: Identifier {
+                            name: "A15",
+                        },
+                    },
+                ],
+                value: None,
+                type: None,
+                flags: [
+                    Public,
+                ],
+            },
+        ],
+        flags: [],
+    },
+    Trait {
+        name: Identifier {
+            name: "F",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    36,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A16",
+                },
+            },
+        ],
+        body: [],
+    },
+    UnitEnum {
+        name: Identifier {
+            name: "P",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    39,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A17",
+                },
+            },
+        ],
+        implements: [],
+        body: [],
+    },
+    BackedEnum {
+        name: Identifier {
+            name: "B",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    42,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A18",
+                },
+            },
+        ],
+        implements: [],
+        backed_type: Int,
+        body: [],
+    },
+    Interface {
+        name: Identifier {
+            name: "I",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    45,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A19",
+                },
+            },
+        ],
+        extends: [],
+        body: [],
+    },
+    Trait {
+        name: Identifier {
+            name: "T",
+        },
+        attributes: [
+            Attribute {
+                span: (
+                    48,
+                    3,
+                ),
+                expression: Identifier {
+                    name: "A20",
+                },
+            },
+        ],
+        body: [],
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable {
+                name: "x",
+            },
+            op: Assign,
+            rhs: Closure {
+                params: [],
+                attributes: [
+                    Attribute {
+                        span: (
+                            51,
+                            8,
+                        ),
+                        expression: Identifier {
+                            name: "A21",
+                        },
+                    },
+                ],
+                uses: [],
+                return_type: None,
+                body: [],
+                static: false,
+                by_ref: false,
+            },
+        },
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable {
+                name: "y",
+            },
+            op: Assign,
+            rhs: ArrowFunction {
+                params: [],
+                attributes: [
+                    Attribute {
+                        span: (
+                            52,
+                            8,
+                        ),
+                        expression: Identifier {
+                            name: "A22",
+                        },
+                    },
+                ],
+                return_type: None,
+                expr: LiteralInteger {
+                    i: 0,
+                },
+                by_ref: false,
+                static: false,
+            },
+        },
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable {
+                name: "a",
+            },
+            op: Assign,
+            rhs: Closure {
+                params: [],
+                attributes: [
+                    Attribute {
+                        span: (
+                            53,
+                            8,
+                        ),
+                        expression: Identifier {
+                            name: "A23",
+                        },
+                    },
+                ],
+                uses: [],
+                return_type: None,
+                body: [],
+                static: true,
+                by_ref: false,
+            },
+        },
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable {
+                name: "b",
+            },
+            op: Assign,
+            rhs: ArrowFunction {
+                params: [],
+                attributes: [
+                    Attribute {
+                        span: (
+                            54,
+                            8,
+                        ),
+                        expression: Identifier {
+                            name: "A24",
+                        },
+                    },
+                ],
+                return_type: None,
+                expr: LiteralInteger {
+                    i: 0,
+                },
+                by_ref: false,
+                static: true,
+            },
+        },
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable {
+                name: "z",
+            },
+            op: Assign,
+            rhs: New {
+                target: AnonymousClass {
+                    attributes: [
+                        Attribute {
+                            span: (
+                                55,
+                                12,
+                            ),
+                            expression: Identifier {
+                                name: "A25",
+                            },
+                        },
+                    ],
+                    extends: None,
+                    implements: [],
+                    body: [
+                        Var {
+                            var: "s",
+                            attributes: [
+                                Attribute {
+                                    span: (
+                                        56,
+                                        7,
+                                    ),
+                                    expression: Identifier {
+                                        name: "A26",
+                                    },
+                                },
+                            ],
+                            value: None,
+                            type: None,
+                        },
+                    ],
+                },
+                args: [],
+            },
+        },
+    },
+]

--- a/tests/0223/code.php
+++ b/tests/0223/code.php
@@ -1,0 +1,58 @@
+<?php
+
+#[
+    A1,
+    A2(),
+    A3(0),
+    A4(x: 1),
+]
+function a(
+    #[A5]
+    int|float $a,
+    #[A6]
+    $c,
+    #[A7] string $b,
+) {
+}
+
+
+#[A8, A9(), A10(foo: bar)]
+class C {
+    #[A11]
+    public function __construct(
+        #[A12]
+        public readonly string $s,
+    ) {}
+
+    #[A13]
+    public function m(
+        #[A14] $param,
+    ) {}
+
+    #[A15]
+    public $prop;
+}
+
+#[A16]
+trait F {}
+
+#[A17]
+enum P {}
+
+#[A18]
+enum B: int {}
+
+#[A19]
+interface I {}
+
+#[A20]
+trait T {}
+
+$x = #[A21] function() {};
+$y = #[A22] fn() => 0;
+$a = #[A23] static function() {};
+$b = #[A24] static fn() => 0;
+$z = new #[A25] class {
+    #[A26]
+    var $s;
+};

--- a/tests/0223/tokens.txt
+++ b/tests/0223/tokens.txt
@@ -1,0 +1,1536 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A1",
+        ),
+        span: (
+            4,
+            5,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            4,
+            7,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A2",
+        ),
+        span: (
+            5,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            5,
+            7,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            5,
+            8,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            5,
+            9,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A3",
+        ),
+        span: (
+            6,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            6,
+            7,
+        ),
+    },
+    Token {
+        kind: LiteralInteger(
+            0,
+        ),
+        span: (
+            6,
+            8,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            6,
+            9,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            6,
+            10,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A4",
+        ),
+        span: (
+            7,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            7,
+            7,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "x",
+        ),
+        span: (
+            7,
+            8,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            7,
+            9,
+        ),
+    },
+    Token {
+        kind: LiteralInteger(
+            1,
+        ),
+        span: (
+            7,
+            11,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            7,
+            12,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            7,
+            13,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            8,
+            1,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            9,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "a",
+        ),
+        span: (
+            9,
+            10,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            9,
+            11,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            10,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A5",
+        ),
+        span: (
+            10,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            10,
+            9,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "int",
+        ),
+        span: (
+            11,
+            5,
+        ),
+    },
+    Token {
+        kind: Pipe,
+        span: (
+            11,
+            8,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "float",
+        ),
+        span: (
+            11,
+            9,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "a",
+        ),
+        span: (
+            11,
+            15,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            11,
+            17,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            12,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A6",
+        ),
+        span: (
+            12,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            12,
+            9,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "c",
+        ),
+        span: (
+            13,
+            5,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            13,
+            7,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            14,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A7",
+        ),
+        span: (
+            14,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            14,
+            9,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "string",
+        ),
+        span: (
+            14,
+            11,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "b",
+        ),
+        span: (
+            14,
+            18,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            14,
+            20,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            15,
+            1,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            15,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            16,
+            1,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            19,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A8",
+        ),
+        span: (
+            19,
+            3,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            19,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A9",
+        ),
+        span: (
+            19,
+            7,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            19,
+            9,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            19,
+            10,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            19,
+            11,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A10",
+        ),
+        span: (
+            19,
+            13,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            19,
+            16,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "foo",
+        ),
+        span: (
+            19,
+            17,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            19,
+            20,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "bar",
+        ),
+        span: (
+            19,
+            22,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            19,
+            25,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            19,
+            26,
+        ),
+    },
+    Token {
+        kind: Class,
+        span: (
+            20,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "C",
+        ),
+        span: (
+            20,
+            7,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            20,
+            9,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            21,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A11",
+        ),
+        span: (
+            21,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            21,
+            10,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            22,
+            5,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            22,
+            12,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "__construct",
+        ),
+        span: (
+            22,
+            21,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            22,
+            32,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            23,
+            9,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A12",
+        ),
+        span: (
+            23,
+            11,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            23,
+            14,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            24,
+            9,
+        ),
+    },
+    Token {
+        kind: Readonly,
+        span: (
+            24,
+            16,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "string",
+        ),
+        span: (
+            24,
+            25,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "s",
+        ),
+        span: (
+            24,
+            32,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            24,
+            34,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            25,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            25,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            25,
+            8,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            27,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A13",
+        ),
+        span: (
+            27,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            27,
+            10,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            28,
+            5,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            28,
+            12,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "m",
+        ),
+        span: (
+            28,
+            21,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            28,
+            22,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            29,
+            9,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A14",
+        ),
+        span: (
+            29,
+            11,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            29,
+            14,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "param",
+        ),
+        span: (
+            29,
+            16,
+        ),
+    },
+    Token {
+        kind: Comma,
+        span: (
+            29,
+            22,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            30,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            30,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            30,
+            8,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            32,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A15",
+        ),
+        span: (
+            32,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            32,
+            10,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            33,
+            5,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "prop",
+        ),
+        span: (
+            33,
+            12,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            33,
+            17,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            34,
+            1,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            36,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A16",
+        ),
+        span: (
+            36,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            36,
+            6,
+        ),
+    },
+    Token {
+        kind: Trait,
+        span: (
+            37,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "F",
+        ),
+        span: (
+            37,
+            7,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            37,
+            9,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            37,
+            10,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            39,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A17",
+        ),
+        span: (
+            39,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            39,
+            6,
+        ),
+    },
+    Token {
+        kind: Enum,
+        span: (
+            40,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "P",
+        ),
+        span: (
+            40,
+            6,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            40,
+            8,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            40,
+            9,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            42,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A18",
+        ),
+        span: (
+            42,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            42,
+            6,
+        ),
+    },
+    Token {
+        kind: Enum,
+        span: (
+            43,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "B",
+        ),
+        span: (
+            43,
+            6,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            43,
+            7,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "int",
+        ),
+        span: (
+            43,
+            9,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            43,
+            13,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            43,
+            14,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            45,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A19",
+        ),
+        span: (
+            45,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            45,
+            6,
+        ),
+    },
+    Token {
+        kind: Interface,
+        span: (
+            46,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "I",
+        ),
+        span: (
+            46,
+            11,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            46,
+            13,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            46,
+            14,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            48,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A20",
+        ),
+        span: (
+            48,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            48,
+            6,
+        ),
+    },
+    Token {
+        kind: Trait,
+        span: (
+            49,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "T",
+        ),
+        span: (
+            49,
+            7,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            49,
+            9,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            49,
+            10,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "x",
+        ),
+        span: (
+            51,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            51,
+            4,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            51,
+            6,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A21",
+        ),
+        span: (
+            51,
+            8,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            51,
+            11,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            51,
+            13,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            51,
+            21,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            51,
+            22,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            51,
+            24,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            51,
+            25,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            51,
+            26,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "y",
+        ),
+        span: (
+            52,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            52,
+            4,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            52,
+            6,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A22",
+        ),
+        span: (
+            52,
+            8,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            52,
+            11,
+        ),
+    },
+    Token {
+        kind: Fn,
+        span: (
+            52,
+            13,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            52,
+            15,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            52,
+            16,
+        ),
+    },
+    Token {
+        kind: DoubleArrow,
+        span: (
+            52,
+            18,
+        ),
+    },
+    Token {
+        kind: LiteralInteger(
+            0,
+        ),
+        span: (
+            52,
+            21,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            52,
+            22,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "a",
+        ),
+        span: (
+            53,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            53,
+            4,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            53,
+            6,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A23",
+        ),
+        span: (
+            53,
+            8,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            53,
+            11,
+        ),
+    },
+    Token {
+        kind: Static,
+        span: (
+            53,
+            13,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            53,
+            20,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            53,
+            28,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            53,
+            29,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            53,
+            31,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            53,
+            32,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            53,
+            33,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "b",
+        ),
+        span: (
+            54,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            54,
+            4,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            54,
+            6,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A24",
+        ),
+        span: (
+            54,
+            8,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            54,
+            11,
+        ),
+    },
+    Token {
+        kind: Static,
+        span: (
+            54,
+            13,
+        ),
+    },
+    Token {
+        kind: Fn,
+        span: (
+            54,
+            20,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            54,
+            22,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            54,
+            23,
+        ),
+    },
+    Token {
+        kind: DoubleArrow,
+        span: (
+            54,
+            25,
+        ),
+    },
+    Token {
+        kind: LiteralInteger(
+            0,
+        ),
+        span: (
+            54,
+            28,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            54,
+            29,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "z",
+        ),
+        span: (
+            55,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            55,
+            4,
+        ),
+    },
+    Token {
+        kind: New,
+        span: (
+            55,
+            6,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            55,
+            10,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A25",
+        ),
+        span: (
+            55,
+            12,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            55,
+            15,
+        ),
+    },
+    Token {
+        kind: Class,
+        span: (
+            55,
+            17,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            55,
+            23,
+        ),
+    },
+    Token {
+        kind: Attribute,
+        span: (
+            56,
+            5,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "A26",
+        ),
+        span: (
+            56,
+            7,
+        ),
+    },
+    Token {
+        kind: RightBracket,
+        span: (
+            56,
+            10,
+        ),
+    },
+    Token {
+        kind: Var,
+        span: (
+            57,
+            5,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "s",
+        ),
+        span: (
+            57,
+            9,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            57,
+            11,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            58,
+            1,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            58,
+            2,
+        ),
+    },
+]


### PR DESCRIPTION
~this handles attributes everywhere except one specific case:~

```php
$e = new #[Foo] class {}
```

~fix for anonymous classes will be in another PR.~


attributes are now supported everywhere: functions, parameters, properties, classes, interfaces, traits, enums, anonymous functions, arrow functions, and anonymous classes.

closes #51 
