### PR TITLE
chore: separate source from state

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ cargo add php-parser-rs
 ### Example
 
 ```rust
-use php_parser_rs::prelude::*;
+use php_parser_rs::parser::Parser;
+use php_parser_rs::lexer::Lexer;
 
 fn main() -> ParseResult<()> {
     let lexer = Lexer::new();
@@ -40,7 +41,7 @@ function hello(): void {
 }
 
 hello();
-    ";
+";
 
     let tokens = lexer.tokenize(code.as_bytes())?;
     let ast = parser.parse(tokens)?;

--- a/bin/snapshot.rs
+++ b/bin/snapshot.rs
@@ -46,8 +46,8 @@ fn main() {
             std::fs::remove_file(&parser_error_filename).unwrap();
         }
 
-        let code = std::fs::read_to_string(&code_filename).unwrap();
-        let tokens = LEXER.tokenize(code.as_bytes());
+        let code = std::fs::read(&code_filename).unwrap();
+        let tokens = LEXER.tokenize(&code);
 
         match tokens {
             Ok(tokens) => {

--- a/src/lexer/byte_string.rs
+++ b/src/lexer/byte_string.rs
@@ -9,17 +9,22 @@ use std::str::from_utf8;
 /// The Trunk lexer and parser work mainly with byte strings because
 /// valid PHP code is not required to be valid UTF-8.
 #[derive(PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
-pub struct ByteString(pub(crate) Vec<u8>);
+pub struct ByteString {
+    pub bytes: Vec<u8>,
+    pub length: usize,
+}
 
 impl ByteString {
     pub fn new(bytes: Vec<u8>) -> Self {
-        ByteString(bytes)
+        let length = bytes.len();
+
+        ByteString { bytes, length }
     }
 }
 
 impl std::fmt::Display for ByteString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for &b in &self.0 {
+        for &b in &self.bytes {
             match b {
                 0 => write!(f, "\\0")?,
                 b'\n' | b'\r' | b'\t' => write!(f, "{}", b.escape_ascii())?,
@@ -35,7 +40,7 @@ impl std::fmt::Display for ByteString {
 impl std::fmt::Debug for ByteString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "\"")?;
-        for &b in &self.0 {
+        for &b in &self.bytes {
             match b {
                 0 => write!(f, "\\0")?,
                 b'\n' | b'\r' | b'\t' => write!(f, "{}", b.escape_ascii())?,
@@ -50,13 +55,13 @@ impl std::fmt::Debug for ByteString {
 
 impl<const N: usize> PartialEq<&[u8; N]> for ByteString {
     fn eq(&self, other: &&[u8; N]) -> bool {
-        &self.0 == other
+        &self.bytes == other
     }
 }
 
 impl<const N: usize> PartialEq<&[u8; N]> for &ByteString {
     fn eq(&self, other: &&[u8; N]) -> bool {
-        &self.0 == other
+        &self.bytes == other
     }
 }
 
@@ -92,7 +97,7 @@ impl From<String> for ByteString {
 
 impl From<ByteString> for String {
     fn from(bytes: ByteString) -> Self {
-        String::from(from_utf8(&bytes.0).unwrap())
+        String::from(from_utf8(&bytes.bytes).unwrap())
     }
 }
 
@@ -100,13 +105,13 @@ impl Deref for ByteString {
     type Target = Vec<u8>;
 
     fn deref(&self) -> &Vec<u8> {
-        &self.0
+        &self.bytes
     }
 }
 
 impl DerefMut for ByteString {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.bytes
     }
 }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,5 +1,6 @@
 pub mod byte_string;
 pub mod error;
+pub mod source;
 pub mod token;
 
 mod macros;
@@ -8,6 +9,7 @@ mod state;
 use crate::lexer::byte_string::ByteString;
 use crate::lexer::error::SyntaxError;
 use crate::lexer::error::SyntaxResult;
+use crate::lexer::source::Source;
 use crate::lexer::state::StackFrame;
 use crate::lexer::state::State;
 use crate::lexer::token::OpenTagKind;
@@ -29,10 +31,10 @@ impl Lexer {
     }
 
     pub fn tokenize<B: ?Sized + AsRef<[u8]>>(&self, input: &B) -> SyntaxResult<Vec<Token>> {
-        let mut state = State::new(input);
+        let mut state = State::new(Source::new(input.as_ref()));
         let mut tokens = Vec::new();
 
-        while state.current.is_some() {
+        while !state.source.eof() {
             match state.frame()? {
                 // The "Initial" state is used to parse inline HTML. It is essentially a catch-all
                 // state that will build up a single token buffer until it encounters an open tag
@@ -44,7 +46,7 @@ impl Lexer {
                     self.skip_whitespace(&mut state);
 
                     // If we have consumed whitespace and then reached the end of the file, we should break.
-                    if state.current.is_none() {
+                    if state.source.eof() {
                         break;
                     }
 
@@ -55,8 +57,8 @@ impl Lexer {
                 // into a single "InlineHtml" token (kind of cheating, oh well).
                 StackFrame::Halted => {
                     tokens.push(Token {
-                        kind: TokenKind::InlineHtml(state.chars[state.cursor..].into()),
-                        span: state.span,
+                        kind: TokenKind::InlineHtml(state.source.read_remaining().into()),
+                        span: state.source.span(),
                     });
                     break;
                 }
@@ -87,7 +89,7 @@ impl Lexer {
                     tokens.push(self.looking_for_property(&mut state)?);
                 }
                 StackFrame::VarOffset => {
-                    if state.current.is_none() {
+                    if state.source.eof() {
                         break;
                     }
 
@@ -100,19 +102,19 @@ impl Lexer {
     }
 
     fn skip_whitespace(&self, state: &mut State) {
-        while let Some(b' ' | b'\n' | b'\r' | b'\t') = state.current {
-            state.next();
+        while let Some(b' ' | b'\n' | b'\r' | b'\t') = state.source.current() {
+            state.source.next();
         }
     }
 
     fn initial(&self, state: &mut State, tokens: &mut Vec<Token>) -> SyntaxResult<()> {
-        let inline_span = state.span;
+        let inline_span = state.source.span();
         let mut buffer = Vec::new();
-        while let Some(char) = state.current {
-            if state.try_read(b"<?php") {
-                let tag_span = state.span;
+        while let Some(char) = state.source.current() {
+            if state.source.at(b"<?php", 5) {
+                let tag_span = state.source.span();
 
-                state.skip(5);
+                state.source.skip(5);
                 state.replace(StackFrame::Scripting);
 
                 if !buffer.is_empty() {
@@ -130,8 +132,8 @@ impl Lexer {
                 return Ok(());
             }
 
-            state.next();
-            buffer.push(char);
+            state.source.next();
+            buffer.push(*char);
         }
 
         tokens.push(Token {
@@ -143,164 +145,168 @@ impl Lexer {
     }
 
     fn scripting(&self, state: &mut State) -> SyntaxResult<Token> {
-        let span = state.span;
-        let kind = match state.peek_buf() {
+        let span = state.source.span();
+        let kind = match state.source.read(3) {
+            [b'!', b'=', b'='] => {
+                state.source.skip(3);
+
+                TokenKind::BangDoubleEquals
+            }
+            [b'?', b'?', b'='] => {
+                state.source.skip(3);
+                TokenKind::CoalesceEqual
+            }
+            [b'?', b'-', b'>'] => {
+                state.source.skip(3);
+                TokenKind::NullsafeArrow
+            }
+            [b'=', b'=', b'='] => {
+                state.source.skip(3);
+                TokenKind::TripleEquals
+            }
+            [b'.', b'.', b'.'] => {
+                state.source.skip(3);
+                TokenKind::Ellipsis
+            }
             [b'`', ..] => {
-                state.next();
+                state.source.next();
                 state.replace(StackFrame::ShellExec);
                 TokenKind::Backtick
             }
             [b'@', ..] => {
-                state.next();
-
+                state.source.next();
                 TokenKind::At
             }
-            [b'!', b'=', b'=', ..] => {
-                state.skip(3);
-                TokenKind::BangDoubleEquals
-            }
             [b'!', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::BangEquals
             }
             [b'!', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Bang
             }
             [b'&', b'&', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::BooleanAnd
             }
             [b'&', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::AmpersandEquals
             }
             [b'&', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Ampersand
             }
             [b'?', b'>', ..] => {
                 // This is a close tag, we can enter "Initial" mode again.
-                state.skip(2);
+                state.source.skip(2);
 
                 state.replace(StackFrame::Initial);
 
                 TokenKind::CloseTag
             }
-            [b'?', b'?', b'=', ..] => {
-                state.skip(3);
-                TokenKind::CoalesceEqual
-            }
             [b'?', b'?', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::Coalesce
             }
             [b'?', b':', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::QuestionColon
             }
-            [b'?', b'-', b'>', ..] => {
-                state.skip(3);
-                TokenKind::NullsafeArrow
-            }
             [b'?', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Question
             }
             [b'=', b'>', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::DoubleArrow
             }
-            [b'=', b'=', b'=', ..] => {
-                state.skip(3);
-                TokenKind::TripleEquals
-            }
             [b'=', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::DoubleEquals
             }
             [b'=', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Equals
             }
             // Single quoted string.
             [b'\'', ..] => {
-                state.next();
+                state.source.next();
                 self.tokenize_single_quote_string(state)?
             }
             [b'b' | b'B', b'\'', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 self.tokenize_single_quote_string(state)?
             }
             [b'"', ..] => {
-                state.next();
+                state.source.next();
                 self.tokenize_double_quote_string(state)?
             }
             [b'b' | b'B', b'"', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 self.tokenize_double_quote_string(state)?
             }
             [b'$', ident_start!(), ..] => {
-                state.next();
+                state.source.next();
                 self.tokenize_variable(state)
             }
             [b'$', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Dollar
             }
             [b'.', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::DotEquals
             }
+            [b'0'..=b'9', ..] => self.tokenize_number(state)?,
             [b'.', b'0'..=b'9', ..] => self.tokenize_number(state)?,
-            [b'.', b'.', b'.', ..] => {
-                state.skip(3);
-                TokenKind::Ellipsis
-            }
             [b'.', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Dot
             }
-            &[b'0'..=b'9', ..] => self.tokenize_number(state)?,
-            &[b'\\', ident_start!(), ..] => {
-                state.next();
+            [b'\\', ident_start!(), ..] => {
+                state.source.next();
 
                 match self.scripting(state)? {
                     Token {
                         kind:
-                            TokenKind::Identifier(ByteString(mut i))
-                            | TokenKind::QualifiedIdentifier(ByteString(mut i)),
+                            TokenKind::Identifier(ByteString { mut bytes, length })
+                            | TokenKind::QualifiedIdentifier(ByteString { mut bytes, length }),
                         ..
                     } => {
-                        i.insert(0, b'\\');
-                        TokenKind::FullyQualifiedIdentifier(i.into())
+                        bytes.insert(0, b'\\');
+
+                        TokenKind::FullyQualifiedIdentifier(ByteString {
+                            bytes,
+                            length: length + 1,
+                        })
                     }
                     s => unreachable!("{:?}", s),
                 }
             }
             [b'\\', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::NamespaceSeparator
             }
-            &[b @ ident_start!(), ..] => {
-                state.next();
+            [b @ ident_start!(), ..] => {
+                state.source.next();
                 let mut qualified = false;
                 let mut last_was_slash = false;
 
-                let mut buffer = vec![b];
-                while let Some(next @ ident!() | next @ b'\\') = state.current {
+                let mut buffer = vec![*b];
+                while let Some(next @ ident!() | next @ b'\\') = state.source.current() {
                     if matches!(next, ident!()) {
-                        buffer.push(next);
-                        state.next();
+                        buffer.push(*next);
+                        state.source.next();
                         last_was_slash = false;
                         continue;
                     }
 
-                    if next == b'\\' && !last_was_slash {
+                    if *next == b'\\' && !last_was_slash {
                         qualified = true;
                         last_was_slash = true;
-                        buffer.push(next);
-                        state.next();
+                        buffer.push(*next);
+                        state.source.next();
                         continue;
                     }
 
@@ -314,12 +320,12 @@ impl Lexer {
                         .unwrap_or_else(|| TokenKind::Identifier(buffer.into()));
 
                     if kind == TokenKind::HaltCompiler {
-                        match state.peek_buf() {
-                            [b'(', b')', b';', ..] => {
-                                state.skip(3);
+                        match state.source.read(3) {
+                            [b'(', b')', b';'] => {
+                                state.source.skip(3);
                                 state.replace(StackFrame::Halted);
                             }
-                            _ => return Err(SyntaxError::InvalidHaltCompiler(state.span)),
+                            _ => return Err(SyntaxError::InvalidHaltCompiler(state.source.span())),
                         }
                     }
 
@@ -327,18 +333,18 @@ impl Lexer {
                 }
             }
             [b'/', b'*', ..] => {
-                state.next();
+                state.source.next();
                 let mut buffer = vec![b'/'];
 
                 loop {
-                    match state.peek_buf() {
-                        [b'*', b'/', ..] => {
-                            state.skip(2);
+                    match state.source.read(2) {
+                        [b'*', b'/'] => {
+                            state.source.skip(2);
                             buffer.extend_from_slice(b"*/");
                             break;
                         }
                         &[t, ..] => {
-                            state.next();
+                            state.source.next();
                             buffer.push(t);
                         }
                         _ => {
@@ -354,28 +360,28 @@ impl Lexer {
                 }
             }
             [b'#', b'[', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::Attribute
             }
-            &[ch @ b'/', b'/', ..] | &[ch @ b'#', ..] => {
-                let mut buffer = if ch == b'/' {
-                    state.skip(2);
+            [ch @ b'/', b'/', ..] | [ch @ b'#', ..] => {
+                let mut buffer = if *ch == b'/' {
+                    state.source.skip(2);
                     b"//".to_vec()
                 } else {
-                    state.next();
+                    state.source.next();
                     b"#".to_vec()
                 };
 
-                while let Some(c) = state.current {
-                    if c == b'\n' {
+                while let Some(c) = state.source.current() {
+                    if *c == b'\n' {
                         break;
                     }
 
-                    buffer.push(c);
-                    state.next();
+                    buffer.push(*c);
+                    state.source.next();
                 }
 
-                state.next();
+                state.source.next();
 
                 if buffer.starts_with(b"#") {
                     TokenKind::HashMarkComment(buffer.into())
@@ -384,154 +390,38 @@ impl Lexer {
                 }
             }
             [b'/', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::SlashEquals
             }
             [b'/', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Slash
             }
             [b'*', b'*', b'=', ..] => {
-                state.skip(3);
+                state.source.skip(3);
                 TokenKind::PowEquals
             }
-            [b'*', b'*', ..] => {
-                state.skip(2);
-                TokenKind::Pow
-            }
-            [b'*', b'=', ..] => {
-                state.skip(2);
-                TokenKind::AsteriskEqual
-            }
-            [b'*', ..] => {
-                state.next();
-                TokenKind::Asterisk
-            }
-            [b'|', b'|', ..] => {
-                state.skip(2);
-                TokenKind::Pipe
-            }
-            [b'|', b'=', ..] => {
-                state.skip(2);
-                TokenKind::PipeEquals
-            }
-            [b'|', ..] => {
-                state.next();
-                TokenKind::Pipe
-            }
-            [b'^', b'=', ..] => {
-                state.skip(2);
-                TokenKind::CaretEquals
-            }
-            [b'^', ..] => {
-                state.next();
-                TokenKind::Caret
-            }
-            [b'{', ..] => {
-                state.next();
-                state.enter(StackFrame::Scripting);
-                TokenKind::LeftBrace
-            }
-            [b'}', ..] => {
-                state.next();
-                state.exit();
-                TokenKind::RightBrace
-            }
-            [b'(', ..] => {
-                state.next();
+            [b'<', b'<', b'='] => {
+                state.source.skip(3);
 
-                if state.try_read(b"int)") {
-                    state.skip(4);
-                    TokenKind::IntCast
-                } else if state.try_read(b"integer)") {
-                    state.skip(8);
-                    TokenKind::IntegerCast
-                } else if state.try_read(b"bool)") {
-                    state.skip(5);
-                    TokenKind::BoolCast
-                } else if state.try_read(b"boolean)") {
-                    state.skip(8);
-                    TokenKind::BooleanCast
-                } else if state.try_read(b"float)") {
-                    state.skip(6);
-                    TokenKind::FloatCast
-                } else if state.try_read(b"double)") {
-                    state.skip(7);
-                    TokenKind::DoubleCast
-                } else if state.try_read(b"real)") {
-                    state.skip(5);
-                    TokenKind::RealCast
-                } else if state.try_read(b"string)") {
-                    state.skip(7);
-                    TokenKind::StringCast
-                } else if state.try_read(b"binary)") {
-                    state.skip(7);
-                    TokenKind::BinaryCast
-                } else if state.try_read(b"array)") {
-                    state.skip(6);
-                    TokenKind::ArrayCast
-                } else if state.try_read(b"object)") {
-                    state.skip(7);
-                    TokenKind::ObjectCast
-                } else if state.try_read(b"unset)") {
-                    state.skip(6);
-                    TokenKind::UnsetCast
-                } else {
-                    TokenKind::LeftParen
-                }
+                TokenKind::LeftShiftEquals
             }
-            [b')', ..] => {
-                state.next();
-                TokenKind::RightParen
+            [b'<', b'=', b'>'] => {
+                state.source.skip(3);
+                TokenKind::Spaceship
             }
-            [b';', ..] => {
-                state.next();
-                TokenKind::SemiColon
+            [b'>', b'>', b'='] => {
+                state.source.skip(3);
+                TokenKind::RightShiftEquals
             }
-            [b'+', b'+', ..] => {
-                state.skip(2);
-                TokenKind::Increment
-            }
-            [b'+', b'=', ..] => {
-                state.skip(2);
-                TokenKind::PlusEquals
-            }
-            [b'+', ..] => {
-                state.next();
-                TokenKind::Plus
-            }
-            [b'%', b'=', ..] => {
-                state.skip(2);
-                TokenKind::PercentEquals
-            }
-            [b'%', ..] => {
-                state.next();
-                TokenKind::Percent
-            }
-            [b'-', b'-', ..] => {
-                state.skip(2);
-                TokenKind::Decrement
-            }
-            [b'-', b'>', ..] => {
-                state.skip(2);
-                TokenKind::Arrow
-            }
-            [b'-', b'=', ..] => {
-                state.skip(2);
-                TokenKind::MinusEquals
-            }
-            [b'-', ..] => {
-                state.next();
-                TokenKind::Minus
-            }
-            [b'<', b'<', b'<', ..] => {
-                state.skip(3);
+            [b'<', b'<', b'<'] => {
+                state.source.skip(3);
 
                 self.skip_whitespace(state);
 
-                let doc_string_kind = match state.peek_buf() {
-                    [b'\'', ..] => {
-                        state.next();
+                let doc_string_kind = match state.source.read(1) {
+                    [b'\''] => {
+                        state.source.next();
                         DocStringKind::Nowdoc
                     }
                     _ => DocStringKind::Heredoc,
@@ -545,187 +435,308 @@ impl Lexer {
                 };
 
                 if doc_string_kind == DocStringKind::Nowdoc {
-                    match state.current {
-                        Some(b'\'') => state.next(),
+                    match state.source.current() {
+                        Some(b'\'') => state.source.next(),
                         _ => {
+                            // TODO(azjezz) this is most likely a bug, what if current is none?
                             return Err(SyntaxError::UnexpectedCharacter(
-                                state.current.unwrap(),
-                                state.span,
-                            ))
+                                *state.source.current().unwrap(),
+                                state.source.span(),
+                            ));
                         }
                     };
                 }
 
-                if !matches!(state.peek_buf(), [b'\n', ..]) {
+                if !matches!(state.source.current(), Some(b'\n')) {
                     return Err(SyntaxError::UnexpectedCharacter(
-                        state.current.unwrap(),
-                        state.span,
+                        *state.source.current().unwrap(),
+                        state.source.span(),
                     ));
                 }
 
-                state.next();
+                state.source.next();
                 state.replace(StackFrame::DocString(doc_string_kind, label.clone()));
 
                 TokenKind::StartDocString(label, doc_string_kind)
             }
-            [b'<', b'<', b'=', ..] => {
-                state.skip(3);
+            [b'*', b'*', ..] => {
+                state.source.skip(2);
+                TokenKind::Pow
+            }
+            [b'*', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::AsteriskEqual
+            }
+            [b'*', ..] => {
+                state.source.next();
+                TokenKind::Asterisk
+            }
+            [b'|', b'|', ..] => {
+                state.source.skip(2);
+                TokenKind::Pipe
+            }
+            [b'|', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::PipeEquals
+            }
+            [b'|', ..] => {
+                state.source.next();
+                TokenKind::Pipe
+            }
+            [b'^', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::CaretEquals
+            }
+            [b'^', ..] => {
+                state.source.next();
+                TokenKind::Caret
+            }
+            [b'{', ..] => {
+                state.source.next();
+                state.enter(StackFrame::Scripting);
+                TokenKind::LeftBrace
+            }
+            [b'}', ..] => {
+                state.source.next();
+                state.exit();
+                TokenKind::RightBrace
+            }
+            [b'(', ..] => {
+                state.source.next();
 
-                TokenKind::LeftShiftEquals
+                if state.source.at(b"int)", 4) {
+                    state.source.skip(4);
+                    TokenKind::IntCast
+                } else if state.source.at(b"integer)", 8) {
+                    state.source.skip(8);
+                    TokenKind::IntegerCast
+                } else if state.source.at(b"bool)", 5) {
+                    state.source.skip(5);
+                    TokenKind::BoolCast
+                } else if state.source.at(b"boolean)", 8) {
+                    state.source.skip(8);
+                    TokenKind::BooleanCast
+                } else if state.source.at(b"float)", 6) {
+                    state.source.skip(6);
+                    TokenKind::FloatCast
+                } else if state.source.at(b"double)", 7) {
+                    state.source.skip(7);
+                    TokenKind::DoubleCast
+                } else if state.source.at(b"real)", 5) {
+                    state.source.skip(5);
+                    TokenKind::RealCast
+                } else if state.source.at(b"string)", 7) {
+                    state.source.skip(7);
+                    TokenKind::StringCast
+                } else if state.source.at(b"binary)", 7) {
+                    state.source.skip(7);
+                    TokenKind::BinaryCast
+                } else if state.source.at(b"array)", 6) {
+                    state.source.skip(6);
+                    TokenKind::ArrayCast
+                } else if state.source.at(b"object)", 7) {
+                    state.source.skip(7);
+                    TokenKind::ObjectCast
+                } else if state.source.at(b"unset)", 6) {
+                    state.source.skip(6);
+                    TokenKind::UnsetCast
+                } else {
+                    TokenKind::LeftParen
+                }
+            }
+            [b')', ..] => {
+                state.source.next();
+                TokenKind::RightParen
+            }
+            [b';', ..] => {
+                state.source.next();
+                TokenKind::SemiColon
+            }
+            [b'+', b'+', ..] => {
+                state.source.skip(2);
+                TokenKind::Increment
+            }
+            [b'+', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::PlusEquals
+            }
+            [b'+', ..] => {
+                state.source.next();
+                TokenKind::Plus
+            }
+            [b'%', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::PercentEquals
+            }
+            [b'%', ..] => {
+                state.source.next();
+                TokenKind::Percent
+            }
+            [b'-', b'-', ..] => {
+                state.source.skip(2);
+                TokenKind::Decrement
+            }
+            [b'-', b'>', ..] => {
+                state.source.skip(2);
+                TokenKind::Arrow
+            }
+            [b'-', b'=', ..] => {
+                state.source.skip(2);
+                TokenKind::MinusEquals
+            }
+            [b'-', ..] => {
+                state.source.next();
+                TokenKind::Minus
             }
             [b'<', b'<', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::LeftShift
             }
-            [b'<', b'=', b'>', ..] => {
-                state.skip(3);
-                TokenKind::Spaceship
-            }
             [b'<', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::LessThanEquals
             }
             [b'<', b'>', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::AngledLeftRight
             }
             [b'<', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::LessThan
             }
-            [b'>', b'>', b'=', ..] => {
-                state.skip(3);
-                TokenKind::RightShiftEquals
-            }
             [b'>', b'>', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::RightShift
             }
             [b'>', b'=', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::GreaterThanEquals
             }
             [b'>', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::GreaterThan
             }
             [b',', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Comma
             }
             [b'[', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::LeftBracket
             }
             [b']', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::RightBracket
             }
             [b':', b':', ..] => {
-                state.skip(2);
+                state.source.skip(2);
                 TokenKind::DoubleColon
             }
             [b':', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Colon
             }
-            &[b'~', ..] => {
-                state.next();
+            [b'~', ..] => {
+                state.source.next();
                 TokenKind::BitwiseNot
             }
-            &[b, ..] => unimplemented!(
+            [b, ..] => unimplemented!(
                 "<scripting> char: {}, line: {}, col: {}",
-                b as char,
-                state.span.0,
-                state.span.1
+                *b as char,
+                state.source.span().0,
+                state.source.span().1
             ),
             // We should never reach this point since we have the empty checks surrounding
             // the call to this function, but it's better to be safe than sorry.
-            [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+            [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
         };
 
         Ok(Token { kind, span })
     }
 
     fn double_quote(&self, state: &mut State, tokens: &mut Vec<Token>) -> SyntaxResult<()> {
-        let span = state.span;
+        let span = state.source.span();
         let mut buffer = Vec::new();
         let kind = loop {
-            match state.peek_buf() {
+            match state.source.read(3) {
                 [b'$', b'{', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     state.enter(StackFrame::LookingForVarname);
                     break TokenKind::DollarLeftBrace;
                 }
                 [b'{', b'$', ..] => {
                     // Intentionally only consume the left brace.
-                    state.next();
+                    state.source.next();
                     state.enter(StackFrame::Scripting);
                     break TokenKind::LeftBrace;
                 }
                 [b'"', ..] => {
-                    state.next();
+                    state.source.next();
                     state.replace(StackFrame::Scripting);
                     break TokenKind::DoubleQuote;
                 }
                 &[b'\\', b @ (b'"' | b'\\' | b'$'), ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b);
                 }
                 &[b'\\', b'n', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\n');
                 }
                 &[b'\\', b'r', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\r');
                 }
                 &[b'\\', b't', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\t');
                 }
                 &[b'\\', b'v', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x0b');
                 }
                 &[b'\\', b'e', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x1b');
                 }
                 &[b'\\', b'f', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x0c');
                 }
-                &[b'\\', b'x', b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F'), ..] => {
-                    state.skip(3);
+                &[b'\\', b'x', b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')] => {
+                    state.source.skip(3);
 
                     let mut hex = String::from(b as char);
-                    if let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) = state.current {
-                        state.next();
-                        hex.push(b as char);
+                    if let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) =
+                        state.source.current()
+                    {
+                        state.source.next();
+                        hex.push(*b as char);
                     }
 
                     let b = u8::from_str_radix(&hex, 16).unwrap();
                     buffer.push(b);
                 }
-                &[b'\\', b'u', b'{', ..] => {
-                    state.skip(3);
+                &[b'\\', b'u', b'{'] => {
+                    state.source.skip(3);
 
                     let mut code_point = String::new();
-                    while let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) = state.current {
-                        state.next();
-                        code_point.push(b as char);
+                    while let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) =
+                        state.source.current()
+                    {
+                        state.source.next();
+                        code_point.push(*b as char);
                     }
 
-                    if code_point.is_empty() || state.current != Some(b'}') {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                    if code_point.is_empty() || state.source.current() != Some(&b'}') {
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     }
-                    state.next();
+                    state.source.next();
 
                     let c = if let Ok(c) = u32::from_str_radix(&code_point, 16) {
                         c
                     } else {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     };
 
                     if let Some(c) = char::from_u32(c) {
@@ -733,36 +744,35 @@ impl Lexer {
                         let bytes = c.encode_utf8(&mut tmp);
                         buffer.extend(bytes.as_bytes());
                     } else {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     }
                 }
                 &[b'\\', b @ b'0'..=b'7', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
 
                     let mut octal = String::from(b as char);
-                    if let Some(b @ b'0'..=b'7') = state.current {
-                        state.next();
-                        octal.push(b as char);
+                    if let Some(b @ b'0'..=b'7') = state.source.current() {
+                        state.source.next();
+                        octal.push(*b as char);
                     }
-                    if let Some(b @ b'0'..=b'7') = state.current {
-                        state.next();
-                        octal.push(b as char);
+                    if let Some(b @ b'0'..=b'7') = state.source.current() {
+                        state.source.next();
+                        octal.push(*b as char);
                     }
 
                     if let Ok(b) = u8::from_str_radix(&octal, 8) {
                         buffer.push(b);
                     } else {
-                        return Err(SyntaxError::InvalidOctalEscape(state.span));
+                        return Err(SyntaxError::InvalidOctalEscape(state.source.span()));
                     }
                 }
                 [b'$', ident_start!(), ..] => {
-                    state.next();
+                    state.source.next();
                     let ident = self.consume_identifier(state);
 
-                    match state.peek_buf() {
+                    match state.source.read(4) {
                         [b'[', ..] => state.enter(StackFrame::VarOffset),
-                        [b'-', b'>', ident_start!(), ..]
-                        | [b'?', b'-', b'>', ident_start!(), ..] => {
+                        [b'-', b'>', ident_start!(), ..] | [b'?', b'-', b'>', ident_start!()] => {
                             state.enter(StackFrame::LookingForProperty)
                         }
                         _ => {}
@@ -771,10 +781,10 @@ impl Lexer {
                     break TokenKind::Variable(ident.into());
                 }
                 &[b, ..] => {
-                    state.next();
+                    state.source.next();
                     buffer.push(b);
                 }
-                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
             }
         };
 
@@ -790,34 +800,33 @@ impl Lexer {
     }
 
     fn shell_exec(&self, state: &mut State, tokens: &mut Vec<Token>) -> SyntaxResult<()> {
-        let span = state.span;
+        let span = state.source.span();
         let mut buffer = Vec::new();
         let kind = loop {
-            match state.peek_buf() {
-                [b'$', b'{', ..] => {
-                    state.skip(2);
+            match state.source.read(2) {
+                [b'$', b'{'] => {
+                    state.source.skip(2);
                     state.enter(StackFrame::LookingForVarname);
                     break TokenKind::DollarLeftBrace;
                 }
-                [b'{', b'$', ..] => {
+                [b'{', b'$'] => {
                     // Intentionally only consume the left brace.
-                    state.next();
+                    state.source.next();
                     state.enter(StackFrame::Scripting);
                     break TokenKind::LeftBrace;
                 }
                 [b'`', ..] => {
-                    state.next();
+                    state.source.next();
                     state.replace(StackFrame::Scripting);
                     break TokenKind::Backtick;
                 }
-                [b'$', ident_start!(), ..] => {
-                    state.next();
+                [b'$', ident_start!()] => {
+                    state.source.next();
                     let ident = self.consume_identifier(state);
 
-                    match state.peek_buf() {
+                    match state.source.read(4) {
                         [b'[', ..] => state.enter(StackFrame::VarOffset),
-                        [b'-', b'>', ident_start!(), ..]
-                        | [b'?', b'-', b'>', ident_start!(), ..] => {
+                        [b'-', b'>', ident_start!(), ..] | [b'?', b'-', b'>', ident_start!()] => {
                             state.enter(StackFrame::LookingForProperty)
                         }
                         _ => {}
@@ -826,10 +835,10 @@ impl Lexer {
                     break TokenKind::Variable(ident.into());
                 }
                 &[b, ..] => {
-                    state.next();
+                    state.source.next();
                     buffer.push(b);
                 }
-                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
             }
         };
 
@@ -852,30 +861,31 @@ impl Lexer {
         kind: DocStringKind,
         label: ByteString,
     ) -> SyntaxResult<()> {
-        let span = state.span;
+        let span = state.source.span();
         let mut buffer = Vec::new();
         let mut new_line = false;
 
-        let mut indentation_type: Option<DocStringIndentationKind> = None;
         let mut indentation_amount: usize = 0;
 
         // 1. Check if there's any whitespace here. It can either be a space or tab character.
-        if matches!(state.peek_buf(), [b' ' | b'\t', ..]) {
-            indentation_type = Some(DocStringIndentationKind::from(state.current.unwrap()));
-        }
+        let indentation_type = match state.source.read(1) {
+            [b' '] => Some(DocStringIndentationKind::Space),
+            [b'\t'] => Some(DocStringIndentationKind::Tab),
+            _ => None,
+        };
 
         // 2. Count how much whitespace there is on this line.
         if let Some(indentation_type) = indentation_type {
             loop {
-                match (indentation_type, state.peek_buf()) {
-                    (DocStringIndentationKind::Space, [b' ', ..]) => {
+                match (indentation_type, state.source.read(1)) {
+                    (DocStringIndentationKind::Space, [b' ']) => {
                         indentation_amount += 1;
-                        state.next();
+                        state.source.next();
                         buffer.push(b' ');
                     }
-                    (DocStringIndentationKind::Tab, [b'\t', ..]) => {
+                    (DocStringIndentationKind::Tab, [b'\t']) => {
                         indentation_amount += 1;
-                        state.next();
+                        state.source.next();
                         buffer.push(b'\t');
                     }
                     _ => break,
@@ -884,26 +894,25 @@ impl Lexer {
         }
 
         let kind = loop {
-            match state.peek_buf() {
-                [b'$', b'{', ..] if kind == DocStringKind::Heredoc => {
-                    state.skip(2);
+            match state.source.read(2) {
+                [b'$', b'{'] if kind == DocStringKind::Heredoc => {
+                    state.source.skip(2);
                     state.enter(StackFrame::LookingForVarname);
                     break TokenKind::DollarLeftBrace;
                 }
-                [b'{', b'$', ..] if kind == DocStringKind::Heredoc => {
+                [b'{', b'$'] if kind == DocStringKind::Heredoc => {
                     // Intentionally only consume the left brace.
-                    state.next();
+                    state.source.next();
                     state.enter(StackFrame::Scripting);
                     break TokenKind::LeftBrace;
                 }
-                [b'$', ident_start!(), ..] if kind == DocStringKind::Heredoc => {
-                    state.next();
+                [b'$', ident_start!()] if kind == DocStringKind::Heredoc => {
+                    state.source.next();
                     let ident = self.consume_identifier(state);
 
-                    match state.peek_buf() {
+                    match state.source.read(4) {
                         [b'[', ..] => state.enter(StackFrame::VarOffset),
-                        [b'-', b'>', ident_start!(), ..]
-                        | [b'?', b'-', b'>', ident_start!(), ..] => {
+                        [b'-', b'>', ident_start!(), ..] | [b'?', b'-', b'>', ident_start!()] => {
                             state.enter(StackFrame::LookingForProperty)
                         }
                         _ => {}
@@ -913,21 +922,21 @@ impl Lexer {
                 }
                 &[b'\n', ..] => {
                     new_line = true;
-                    state.next();
+                    state.source.next();
                     buffer.push(b'\n');
                 }
                 &[b, ..] => {
                     // If we're not on a new line, just add to the buffer as usual.
                     if !new_line {
                         new_line = false;
-                        state.next();
+                        state.source.next();
                         buffer.push(b);
                         continue;
                     }
 
                     // If we can see the label here, we can consume it and exit early.
-                    if state.try_read(&label) {
-                        state.skip(label.len());
+                    if state.source.at(&label, label.length) {
+                        state.source.skip(label.length);
                         state.replace(StackFrame::Scripting);
                         break TokenKind::EndDocString(label, None, 0);
                     }
@@ -935,15 +944,15 @@ impl Lexer {
                     // We know the label isn't at the start of the line, so we can
                     // check if the line starts with any whitespace.
                     let line_starts_with_whitespace =
-                        matches!(state.peek_buf(), [b' ' | b'\t', ..]);
+                        matches!(state.source.read(1), [b' '] | [b'\t']);
                     let mut current_indentation_amount = 0;
 
                     // If the line does start with whitespace, let's figure out what the current
                     // indentation type is and how much whitespace there is.
                     if line_starts_with_whitespace {
-                        let current_indentation_type = match state.peek_buf() {
-                            [b' ', ..] => DocStringIndentationKind::Space,
-                            [b'\t', ..] => DocStringIndentationKind::Tab,
+                        let current_indentation_type = match state.source.read(1) {
+                            [b' '] => DocStringIndentationKind::Space,
+                            [b'\t'] => DocStringIndentationKind::Tab,
                             _ => unreachable!(),
                         };
 
@@ -952,7 +961,9 @@ impl Lexer {
                         // If it's different, we need to produce an error.
                         if let Some(indentation_type) = indentation_type {
                             if indentation_type != current_indentation_type {
-                                return Err(SyntaxError::InvalidDocIndentation(state.span));
+                                return Err(SyntaxError::InvalidDocIndentation(
+                                    state.source.span(),
+                                ));
                             }
                         }
 
@@ -962,16 +973,16 @@ impl Lexer {
                         // how much whitespace is on this line. We only care about
                         // the smallest amount of whitespace in this case.
                         loop {
-                            match (current_indentation_type, state.peek_buf()) {
-                                (DocStringIndentationKind::Space, [b' ', ..]) => {
+                            match (current_indentation_type, state.source.read(1)) {
+                                (DocStringIndentationKind::Space, [b' ']) => {
                                     leading_whitespace_buffer.push(b' ');
                                     current_indentation_amount += 1;
-                                    state.next();
+                                    state.source.next();
                                 }
-                                (DocStringIndentationKind::Tab, [b'\t', ..]) => {
+                                (DocStringIndentationKind::Tab, [b'\t']) => {
                                     leading_whitespace_buffer.push(b'\t');
                                     current_indentation_amount += 1;
-                                    state.next();
+                                    state.source.next();
                                 }
                                 _ => break,
                             };
@@ -979,11 +990,12 @@ impl Lexer {
 
                         // If we can read the label at this point, we then need to check if the amount
                         // of indentation is the same or less than the smallest amount encountered thus far.
-                        if state.try_read(&label) && current_indentation_amount > indentation_amount
+                        if state.source.at(&label, label.length)
+                            && current_indentation_amount > indentation_amount
                         {
                             return Err(SyntaxError::InvalidDocBodyIndentationLevel(
                                 current_indentation_amount,
-                                state.span,
+                                state.source.span(),
                             ));
                         }
 
@@ -998,24 +1010,27 @@ impl Lexer {
                         // can include spaces or tabs. We should also push it to the buffer,
                         // in case we don't encounter the label. In theory, the only whitespace
                         // we'll encounter here is the character not found by the checks above.
-                        while let [b @ b' ' | b @ b'\t', ..] = state.peek_buf() {
+                        while let [b @ b' ' | b @ b'\t'] = state.source.read(1) {
                             whitespace_buffer.push(*b);
-                            state.next();
+                            state.source.next();
                         }
 
                         // Check if we can read the label again now.
-                        if state.try_read(&label) {
+                        if state.source.at(&label, label.length) {
                             // If there was extra whitespace after indentation, we need
                             // to error out about mixed indentation types.
                             if !whitespace_buffer.is_empty() {
-                                return Err(SyntaxError::InvalidDocIndentation(state.span));
+                                return Err(SyntaxError::InvalidDocIndentation(
+                                    state.source.span(),
+                                ));
                             }
 
                             // If no extra whitespace was found, we've reached the end of the heredoc
                             // and can consume the label, sending the indentation amount along to the parser
                             // to normalize.
-                            state.skip(label.len());
+                            state.source.skip(label.length);
                             state.replace(StackFrame::Scripting);
+
                             break TokenKind::EndDocString(
                                 label,
                                 indentation_type,
@@ -1028,11 +1043,11 @@ impl Lexer {
                         }
                     } else {
                         new_line = false;
-                        state.next();
+                        state.source.next();
                         buffer.push(b);
                     }
                 }
-                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
             }
         };
 
@@ -1057,10 +1072,10 @@ impl Lexer {
         let identifier = self.peek_identifier(state);
 
         if let Some(ident) = identifier {
-            if let Some(b'[' | b'}') = state.peek_byte(ident.len()) {
+            if let [b'[' | b'}'] = state.source.peek(ident.len(), 1) {
                 let ident = ident.to_vec();
-                let span = state.span;
-                state.skip(ident.len());
+                let span = state.source.span();
+                state.source.skip(ident.len());
                 state.replace(StackFrame::Scripting);
                 return Ok(Some(Token {
                     kind: TokenKind::Identifier(ident.into()),
@@ -1075,15 +1090,15 @@ impl Lexer {
     }
 
     fn looking_for_property(&self, state: &mut State) -> SyntaxResult<Token> {
-        let span = state.span;
-        let kind = match state.peek_buf() {
-            [b'-', b'>', ..] => {
-                state.skip(2);
-                TokenKind::Arrow
-            }
-            [b'?', b'-', b'>', ..] => {
-                state.skip(3);
+        let span = state.source.span();
+        let kind = match state.source.read(3) {
+            [b'?', b'-', b'>'] => {
+                state.source.skip(3);
                 TokenKind::NullsafeArrow
+            }
+            [b'-', b'>', ..] => {
+                state.source.skip(2);
+                TokenKind::Arrow
             }
             &[ident_start!(), ..] => {
                 let buffer = self.consume_identifier(state);
@@ -1093,32 +1108,33 @@ impl Lexer {
             // Should be impossible as we already looked ahead this far inside double_quote.
             _ => unreachable!(),
         };
+
         Ok(Token { kind, span })
     }
 
     fn var_offset(&self, state: &mut State) -> SyntaxResult<Token> {
-        let span = state.span;
-        let kind = match state.peek_buf() {
-            [b'$', ident_start!(), ..] => {
-                state.next();
+        let span = state.source.span();
+        let kind = match state.source.read(2) {
+            [b'$', ident_start!()] => {
+                state.source.next();
                 self.tokenize_variable(state)
             }
-            &[b'0'..=b'9', ..] => {
+            [b'0'..=b'9', ..] => {
                 // TODO: all integer literals are allowed, but only decimal integers with no underscores
                 // are actually treated as numbers. Others are treated as strings.
                 // Float literals are not allowed, but that could be handled in the parser.
                 self.tokenize_number(state)?
             }
             [b'[', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::LeftBracket
             }
             [b'-', ..] => {
-                state.next();
+                state.source.next();
                 TokenKind::Minus
             }
             [b']', ..] => {
-                state.next();
+                state.source.next();
                 state.exit();
                 TokenKind::RightBracket
             }
@@ -1126,8 +1142,8 @@ impl Lexer {
                 let label = self.consume_identifier(state);
                 TokenKind::Identifier(label.into())
             }
-            &[b, ..] => return Err(SyntaxError::UnrecognisedToken(b, state.span)),
-            [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+            &[b, ..] => return Err(SyntaxError::UnrecognisedToken(b, state.source.span())),
+            [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
         };
         Ok(Token { kind, span })
     }
@@ -1136,20 +1152,20 @@ impl Lexer {
         let mut buffer = Vec::new();
 
         loop {
-            match state.peek_buf() {
+            match state.source.read(2) {
                 [b'\'', ..] => {
-                    state.next();
+                    state.source.next();
                     break;
                 }
-                &[b'\\', b @ b'\'' | b @ b'\\', ..] => {
-                    state.skip(2);
+                &[b'\\', b @ b'\'' | b @ b'\\'] => {
+                    state.source.skip(2);
                     buffer.push(b);
                 }
                 &[b, ..] => {
-                    state.next();
+                    state.source.next();
                     buffer.push(b);
                 }
-                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
             }
         }
 
@@ -1160,69 +1176,73 @@ impl Lexer {
         let mut buffer = Vec::new();
 
         let constant = loop {
-            match state.peek_buf() {
+            match state.source.read(3) {
                 [b'"', ..] => {
-                    state.next();
+                    state.source.next();
                     break true;
                 }
                 &[b'\\', b @ (b'"' | b'\\' | b'$'), ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b);
                 }
                 &[b'\\', b'n', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\n');
                 }
                 &[b'\\', b'r', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\r');
                 }
                 &[b'\\', b't', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\t');
                 }
                 &[b'\\', b'v', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x0b');
                 }
                 &[b'\\', b'e', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x1b');
                 }
                 &[b'\\', b'f', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
                     buffer.push(b'\x0c');
                 }
-                &[b'\\', b'x', b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F'), ..] => {
-                    state.skip(3);
+                &[b'\\', b'x', b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')] => {
+                    state.source.skip(3);
 
                     let mut hex = String::from(b as char);
-                    if let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) = state.current {
-                        state.next();
-                        hex.push(b as char);
+                    if let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) =
+                        state.source.current()
+                    {
+                        state.source.next();
+                        hex.push(*b as char);
                     }
 
                     let b = u8::from_str_radix(&hex, 16).unwrap();
                     buffer.push(b);
                 }
-                &[b'\\', b'u', b'{', ..] => {
-                    state.skip(3);
+                &[b'\\', b'u', b'{'] => {
+                    state.source.skip(3);
 
                     let mut code_point = String::new();
-                    while let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) = state.current {
-                        state.next();
-                        code_point.push(b as char);
+                    while let Some(b @ (b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')) =
+                        state.source.current()
+                    {
+                        state.source.next();
+                        code_point.push(*b as char);
                     }
 
-                    if code_point.is_empty() || state.current != Some(b'}') {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                    if code_point.is_empty() || state.source.current() != Some(&b'}') {
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     }
-                    state.next();
+                    state.source.next();
 
                     let c = if let Ok(c) = u32::from_str_radix(&code_point, 16) {
                         c
                     } else {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     };
 
                     if let Some(c) = char::from_u32(c) {
@@ -1230,36 +1250,37 @@ impl Lexer {
                         let bytes = c.encode_utf8(&mut tmp);
                         buffer.extend(bytes.as_bytes());
                     } else {
-                        return Err(SyntaxError::InvalidUnicodeEscape(state.span));
+                        return Err(SyntaxError::InvalidUnicodeEscape(state.source.span()));
                     }
                 }
                 &[b'\\', b @ b'0'..=b'7', ..] => {
-                    state.skip(2);
+                    state.source.skip(2);
 
                     let mut octal = String::from(b as char);
-                    if let Some(b @ b'0'..=b'7') = state.current {
-                        state.next();
-                        octal.push(b as char);
+                    if let Some(b @ b'0'..=b'7') = state.source.current() {
+                        state.source.next();
+                        octal.push(*b as char);
                     }
-                    if let Some(b @ b'0'..=b'7') = state.current {
-                        state.next();
-                        octal.push(b as char);
+
+                    if let Some(b @ b'0'..=b'7') = state.source.current() {
+                        state.source.next();
+                        octal.push(*b as char);
                     }
 
                     if let Ok(b) = u8::from_str_radix(&octal, 8) {
                         buffer.push(b);
                     } else {
-                        return Err(SyntaxError::InvalidOctalEscape(state.span));
+                        return Err(SyntaxError::InvalidOctalEscape(state.source.span()));
                     }
                 }
                 [b'$', ident_start!(), ..] | [b'{', b'$', ..] | [b'$', b'{', ..] => {
                     break false;
                 }
                 &[b, ..] => {
-                    state.next();
+                    state.source.next();
                     buffer.push(b);
                 }
-                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.span)),
+                [] => return Err(SyntaxError::UnexpectedEndOfFile(state.source.span())),
             }
         };
 
@@ -1271,14 +1292,16 @@ impl Lexer {
         })
     }
 
-    fn peek_identifier<'a>(&'a self, state: &'a State) -> Option<&[u8]> {
-        let mut cursor = state.cursor;
-        if let Some(ident_start!()) = state.chars.get(cursor) {
-            cursor += 1;
-            while let Some(ident!()) = state.chars.get(cursor) {
-                cursor += 1;
+    fn peek_identifier<'a>(&'a self, state: &'a State) -> Option<&'a [u8]> {
+        let mut size = 0;
+
+        if let [ident_start!()] = state.source.read(1) {
+            size += 1;
+            while let [ident!()] = state.source.peek(size, 1) {
+                size += 1;
             }
-            Some(&state.chars[state.cursor..cursor])
+
+            Some(state.source.read(size))
         } else {
             None
         }
@@ -1286,7 +1309,7 @@ impl Lexer {
 
     fn consume_identifier(&self, state: &mut State) -> Vec<u8> {
         let ident = self.peek_identifier(state).unwrap().to_vec();
-        state.skip(ident.len());
+        state.source.skip(ident.len());
 
         ident
     }
@@ -1298,23 +1321,23 @@ impl Lexer {
     fn tokenize_number(&self, state: &mut State) -> SyntaxResult<TokenKind> {
         let mut buffer = Vec::new();
 
-        let (base, kind) = match state.peek_buf() {
-            [a @ b'0', b @ b'B' | b @ b'b', ..] => {
+        let (base, kind) = match state.source.read(2) {
+            [a @ b'0', b @ b'B' | b @ b'b'] => {
                 buffer.push(*a);
                 buffer.push(*b);
-                state.skip(2);
+                state.source.skip(2);
                 (2, NumberKind::Int)
             }
-            [a @ b'0', b @ b'O' | b @ b'o', ..] => {
+            [a @ b'0', b @ b'O' | b @ b'o'] => {
                 buffer.push(*a);
                 buffer.push(*b);
-                state.skip(2);
+                state.source.skip(2);
                 (8, NumberKind::Int)
             }
-            [a @ b'0', b @ b'X' | b @ b'x', ..] => {
+            [a @ b'0', b @ b'X' | b @ b'x'] => {
                 buffer.push(*a);
                 buffer.push(*b);
-                state.skip(2);
+                state.source.skip(2);
                 (16, NumberKind::Int)
             }
             [b'0', ..] => (10, NumberKind::OctalOrFloat),
@@ -1331,27 +1354,26 @@ impl Lexer {
 
         // Remaining cases: decimal integer, legacy octal integer, or float.
         let is_float = matches!(
-            state.peek_buf(),
-            [b'.', ..]
-                | [b'e' | b'E', b'-' | b'+', b'0'..=b'9', ..]
-                | [b'e' | b'E', b'0'..=b'9', ..]
+            state.source.read(3),
+            [b'.', ..] | [b'e' | b'E', b'-' | b'+', b'0'..=b'9'] | [b'e' | b'E', b'0'..=b'9', ..]
         );
+
         if !is_float {
             return parse_int(&buffer);
         }
 
-        if state.current == Some(b'.') {
+        if let Some(b'.') = state.source.current() {
             buffer.push(b'.');
-            state.next();
+            state.source.next();
             self.read_digits(state, &mut buffer, 10);
         }
 
-        if let Some(b'e' | b'E') = state.current {
+        if let Some(b'e' | b'E') = state.source.current() {
             buffer.push(b'e');
-            state.next();
-            if let Some(b @ (b'-' | b'+')) = state.current {
-                buffer.push(b);
-                state.next();
+            state.source.next();
+            if let Some(b @ (b'-' | b'+')) = state.source.current() {
+                buffer.push(*b);
+                state.source.next();
             }
             self.read_digits(state, &mut buffer, 10);
         }
@@ -1374,24 +1396,25 @@ impl Lexer {
         buffer: &mut Vec<u8>,
         is_digit: F,
     ) {
-        if let Some(b) = state.current {
-            if is_digit(&b) {
-                state.next();
-                buffer.push(b);
+        if let Some(b) = state.source.current() {
+            if is_digit(b) {
+                state.source.next();
+                buffer.push(*b);
             } else {
                 return;
             }
         }
+
         loop {
-            match *state.peek_buf() {
-                [b, ..] if is_digit(&b) => {
-                    state.next();
-                    buffer.push(b);
+            match state.source.read(2) {
+                [b, ..] if is_digit(b) => {
+                    state.source.next();
+                    buffer.push(*b);
                 }
-                [b'_', b, ..] if is_digit(&b) => {
-                    state.next();
-                    state.next();
-                    buffer.push(b);
+                [b'_', b] if is_digit(b) => {
+                    state.source.next();
+                    state.source.next();
+                    buffer.push(*b);
                 }
                 _ => {
                     break;

--- a/src/lexer/source.rs
+++ b/src/lexer/source.rs
@@ -1,0 +1,126 @@
+use crate::lexer::token::Span;
+
+#[derive(Debug)]
+pub struct Source<'a> {
+    input: &'a [u8],
+    length: usize,
+    cursor: usize,
+    span: Span,
+}
+
+impl<'a> Source<'a> {
+    pub fn new(input: &'a [u8]) -> Self {
+        let input = input;
+        let length = input.len();
+
+        Self {
+            input,
+            length,
+            cursor: 0,
+            span: (1, 1),
+        }
+    }
+
+    pub fn from<B: ?Sized + AsRef<[u8]>>(input: &'a B) -> Self {
+        Self::new(input.as_ref())
+    }
+
+    pub const fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    pub const fn span(&self) -> Span {
+        self.span
+    }
+
+    pub const fn eof(&self) -> bool {
+        self.cursor >= self.length
+    }
+
+    pub fn next(&mut self) {
+        if !self.eof() {
+            match self.input[self.cursor] {
+                b'\n' => {
+                    self.span.0 += 1;
+                    self.span.1 = 1;
+                }
+                _ => self.span.1 += 1,
+            }
+        }
+
+        self.cursor += 1;
+    }
+
+    pub fn skip(&mut self, count: usize) {
+        for _ in 0..count {
+            self.next();
+        }
+    }
+
+    pub fn current(&self) -> Option<&'a u8> {
+        if self.cursor >= self.length {
+            None
+        } else {
+            Some(&self.input[self.cursor])
+        }
+    }
+
+    pub fn read(&self, n: usize) -> &'a [u8] {
+        let (from, until) = self.to_bound(n);
+
+        &self.input[from..until]
+    }
+
+    pub fn read_remaining(&self) -> &'a [u8] {
+        let from = self.from_bound();
+
+        &self.input[from..]
+    }
+
+    pub fn at(&self, search: &[u8], len: usize) -> bool {
+        self.read(len) == search
+    }
+
+    pub fn peek(&self, i: usize, n: usize) -> &'a [u8] {
+        let (from, until) = self.bound(i, n);
+
+        &self.input[from..until]
+    }
+
+    const fn bound(&self, i: usize, n: usize) -> (usize, usize) {
+        let from = self.cursor + i;
+        if from >= self.length {
+            return (self.length, self.length);
+        }
+
+        let mut until = from + n;
+
+        if until >= self.length {
+            until = self.length;
+        }
+
+        (from, until)
+    }
+
+    const fn to_bound(&self, n: usize) -> (usize, usize) {
+        if self.cursor >= self.length {
+            return (self.length, self.length);
+        }
+
+        let mut until = self.cursor + n;
+
+        if until >= self.length {
+            until = self.length;
+        }
+
+        (self.cursor, until)
+    }
+
+    const fn from_bound(&self) -> usize {
+        if self.cursor >= self.length {
+            self.length
+        } else {
+            self.cursor
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> ParseResult<()> {
         }
     };
 
-    let contents = match std::fs::read_to_string(&file) {
+    let contents = match std::fs::read(&file) {
         Ok(contents) => contents,
         Err(error) => {
             println!("Failed to read file: {}", error);
@@ -24,7 +24,7 @@ fn main() -> ParseResult<()> {
     let lexer = Lexer::new();
     let parser = Parser::new();
 
-    let tokens = lexer.tokenize(contents.as_bytes())?;
+    let tokens = lexer.tokenize(&contents)?;
     dbg!(&tokens);
 
     let ast = parser.parse(tokens)?;

--- a/tests/fixtures/0269/ast.txt
+++ b/tests/fixtures/0269/ast.txt
@@ -1,0 +1,504 @@
+[
+    Constant {
+        constants: [
+            Constant {
+                name: Identifier {
+                    start: (
+                        3,
+                        7,
+                    ),
+                    name: "\xe2\x86\xaa",
+                    end: (
+                        3,
+                        11,
+                    ),
+                },
+                value: LiteralString {
+                    value: "\n",
+                },
+            },
+        ],
+    },
+    Interface {
+        name: Identifier {
+            start: (
+                5,
+                11,
+            ),
+            name: "\xf0\x9f\x94\x8a",
+            end: (
+                5,
+                16,
+            ),
+        },
+        attributes: [],
+        extends: [],
+        body: [
+            Method(
+                Method {
+                    start: (
+                        6,
+                        3,
+                    ),
+                    end: (
+                        6,
+                        43,
+                    ),
+                    name: Identifier {
+                        start: (
+                            6,
+                            19,
+                        ),
+                        name: "\xf0\x9f\x93\x9d",
+                        end: (
+                            6,
+                            23,
+                        ),
+                    },
+                    attributes: [],
+                    parameters: MethodParameterList {
+                        start: (
+                            6,
+                            23,
+                        ),
+                        end: (
+                            6,
+                            37,
+                        ),
+                        members: [
+                            MethodParameter {
+                                start: (
+                                    6,
+                                    24,
+                                ),
+                                end: (
+                                    6,
+                                    36,
+                                ),
+                                name: Variable {
+                                    start: (
+                                        6,
+                                        31,
+                                    ),
+                                    name: "\xf0\x9f\x93\x83",
+                                    end: (
+                                        6,
+                                        36,
+                                    ),
+                                },
+                                attributes: [],
+                                type: Some(
+                                    String,
+                                ),
+                                variadic: false,
+                                default: None,
+                                modifiers: PromotedPropertyModifierGroup {
+                                    modifiers: [],
+                                },
+                                by_ref: false,
+                            },
+                        ],
+                    },
+                    body: None,
+                    modifiers: MethodModifierGroup {
+                        modifiers: [
+                            Public {
+                                start: (
+                                    6,
+                                    3,
+                                ),
+                                end: (
+                                    6,
+                                    10,
+                                ),
+                            },
+                        ],
+                    },
+                    return_type: Some(
+                        Void,
+                    ),
+                    by_ref: false,
+                },
+            ),
+        ],
+    },
+    Class {
+        name: Identifier {
+            start: (
+                9,
+                13,
+            ),
+            name: "\xf0\x9f\x92\xbb",
+            end: (
+                9,
+                18,
+            ),
+        },
+        attributes: [],
+        extends: None,
+        implements: [
+            Identifier {
+                start: (
+                    9,
+                    29,
+                ),
+                name: "\xf0\x9f\x94\x8a",
+                end: (
+                    9,
+                    34,
+                ),
+            },
+        ],
+        body: [
+            Method(
+                Method {
+                    start: (
+                        10,
+                        3,
+                    ),
+                    end: (
+                        12,
+                        3,
+                    ),
+                    name: Identifier {
+                        start: (
+                            10,
+                            19,
+                        ),
+                        name: "\xf0\x9f\x93\x9d",
+                        end: (
+                            10,
+                            23,
+                        ),
+                    },
+                    attributes: [],
+                    parameters: MethodParameterList {
+                        start: (
+                            10,
+                            23,
+                        ),
+                        end: (
+                            10,
+                            37,
+                        ),
+                        members: [
+                            MethodParameter {
+                                start: (
+                                    10,
+                                    24,
+                                ),
+                                end: (
+                                    10,
+                                    36,
+                                ),
+                                name: Variable {
+                                    start: (
+                                        10,
+                                        31,
+                                    ),
+                                    name: "\xf0\x9f\x93\x83",
+                                    end: (
+                                        10,
+                                        36,
+                                    ),
+                                },
+                                attributes: [],
+                                type: Some(
+                                    String,
+                                ),
+                                variadic: false,
+                                default: None,
+                                modifiers: PromotedPropertyModifierGroup {
+                                    modifiers: [],
+                                },
+                                by_ref: false,
+                            },
+                        ],
+                    },
+                    body: Some(
+                        [
+                            Expression {
+                                expr: Print {
+                                    value: Infix {
+                                        lhs: Variable(
+                                            Variable {
+                                                start: (
+                                                    11,
+                                                    11,
+                                                ),
+                                                name: "\xf0\x9f\x93\x83",
+                                                end: (
+                                                    11,
+                                                    17,
+                                                ),
+                                            },
+                                        ),
+                                        op: Concat,
+                                        rhs: Identifier(
+                                            Identifier {
+                                                start: (
+                                                    11,
+                                                    19,
+                                                ),
+                                                name: "\xe2\x86\xaa",
+                                                end: (
+                                                    11,
+                                                    22,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                },
+                            },
+                        ],
+                    ),
+                    modifiers: MethodModifierGroup {
+                        modifiers: [
+                            Public {
+                                start: (
+                                    10,
+                                    3,
+                                ),
+                                end: (
+                                    10,
+                                    10,
+                                ),
+                            },
+                        ],
+                    },
+                    return_type: Some(
+                        Void,
+                    ),
+                    by_ref: false,
+                },
+            ),
+        ],
+        modifiers: ClassModifierGroup {
+            modifiers: [
+                Final {
+                    start: (
+                        9,
+                        1,
+                    ),
+                    end: (
+                        9,
+                        7,
+                    ),
+                },
+            ],
+        },
+    },
+    Function(
+        Function {
+            start: (
+                15,
+                1,
+            ),
+            end: (
+                19,
+                1,
+            ),
+            name: Identifier {
+                start: (
+                    15,
+                    10,
+                ),
+                name: "\xf0\x9f\x9a\xaa",
+                end: (
+                    15,
+                    14,
+                ),
+            },
+            attributes: [],
+            parameters: FunctionParameterList {
+                start: (
+                    15,
+                    14,
+                ),
+                end: (
+                    15,
+                    16,
+                ),
+                members: [],
+            },
+            return_type: Some(
+                Void,
+            ),
+            by_ref: false,
+            body: [
+                Expression {
+                    expr: Infix {
+                        lhs: Variable(
+                            Variable {
+                                start: (
+                                    16,
+                                    3,
+                                ),
+                                name: "\xf0\x9f\x92\xbb",
+                                end: (
+                                    16,
+                                    9,
+                                ),
+                            },
+                        ),
+                        op: Assign,
+                        rhs: New {
+                            target: Identifier(
+                                Identifier {
+                                    start: (
+                                        16,
+                                        15,
+                                    ),
+                                    name: "\xf0\x9f\x92\xbb",
+                                    end: (
+                                        16,
+                                        19,
+                                    ),
+                                },
+                            ),
+                            args: [],
+                        },
+                    },
+                },
+                Expression {
+                    expr: Infix {
+                        lhs: Variable(
+                            Variable {
+                                start: (
+                                    17,
+                                    3,
+                                ),
+                                name: "\xf0\x9f\x93\x84",
+                                end: (
+                                    17,
+                                    9,
+                                ),
+                            },
+                        ),
+                        op: Assign,
+                        rhs: LiteralString {
+                            value: "hello, world",
+                        },
+                    },
+                },
+                Expression {
+                    expr: MethodCall {
+                        target: Variable(
+                            Variable {
+                                start: (
+                                    18,
+                                    3,
+                                ),
+                                name: "\xf0\x9f\x92\xbb",
+                                end: (
+                                    18,
+                                    8,
+                                ),
+                            },
+                        ),
+                        method: Identifier(
+                            Identifier {
+                                start: (
+                                    18,
+                                    10,
+                                ),
+                                name: "\xf0\x9f\x93\x9d",
+                                end: (
+                                    18,
+                                    14,
+                                ),
+                            },
+                        ),
+                        args: [
+                            Arg {
+                                name: Some(
+                                    Identifier {
+                                        start: (
+                                            18,
+                                            15,
+                                        ),
+                                        name: "\xf0\x9f\x93\x83",
+                                        end: (
+                                            18,
+                                            19,
+                                        ),
+                                    },
+                                ),
+                                value: Variable(
+                                    Variable {
+                                        start: (
+                                            18,
+                                            21,
+                                        ),
+                                        name: "\xf0\x9f\x93\x84",
+                                        end: (
+                                            18,
+                                            26,
+                                        ),
+                                    },
+                                ),
+                                unpack: false,
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ),
+    Expression {
+        expr: Call {
+            target: Identifier(
+                Identifier {
+                    start: (
+                        21,
+                        1,
+                    ),
+                    name: "\xf0\x9f\x9a\xaa",
+                    end: (
+                        21,
+                        5,
+                    ),
+                },
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: Infix {
+            lhs: Variable(
+                Variable {
+                    start: (
+                        23,
+                        1,
+                    ),
+                    name: "var\xef\xbf\xbd",
+                    end: (
+                        23,
+                        9,
+                    ),
+                },
+            ),
+            op: Assign,
+            rhs: LiteralInteger {
+                i: "1",
+            },
+        },
+    },
+    Echo {
+        values: [
+            Variable(
+                Variable {
+                    start: (
+                        23,
+                        19,
+                    ),
+                    name: "var\xef\xbf\xbd",
+                    end: (
+                        23,
+                        26,
+                    ),
+                },
+            ),
+        ],
+    },
+]

--- a/tests/fixtures/0269/code.php
+++ b/tests/fixtures/0269/code.php
@@ -1,0 +1,23 @@
+<?php
+
+const ↪ = "\n";
+
+interface 🔊 {
+  public function 📝(string $📃): void;
+}
+
+final class 💻 implements 🔊 {
+  public function 📝(string $📃): void {
+    print($📃 . ↪);
+  }
+}
+
+function 🚪(): void {
+  $💻 = new 💻();
+  $📄 = "hello, world";
+  $💻->📝(📃: $📄);
+}
+
+🚪();
+
+$var� = 1; echo $var�;

--- a/tests/fixtures/0269/tokens.txt
+++ b/tests/fixtures/0269/tokens.txt
@@ -1,0 +1,650 @@
+[
+    Token {
+        kind: OpenTag(
+            Full,
+        ),
+        span: (
+            1,
+            1,
+        ),
+    },
+    Token {
+        kind: Const,
+        span: (
+            3,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xe2\x86\xaa",
+        ),
+        span: (
+            3,
+            7,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            3,
+            11,
+        ),
+    },
+    Token {
+        kind: LiteralString(
+            "\n",
+        ),
+        span: (
+            3,
+            13,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            3,
+            17,
+        ),
+    },
+    Token {
+        kind: Interface,
+        span: (
+            5,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x94\x8a",
+        ),
+        span: (
+            5,
+            11,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            5,
+            16,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            6,
+            3,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            6,
+            10,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x93\x9d",
+        ),
+        span: (
+            6,
+            19,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            6,
+            23,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "string",
+        ),
+        span: (
+            6,
+            24,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x93\x83",
+        ),
+        span: (
+            6,
+            31,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            6,
+            36,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            6,
+            37,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "void",
+        ),
+        span: (
+            6,
+            39,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            6,
+            43,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            7,
+            1,
+        ),
+    },
+    Token {
+        kind: Final,
+        span: (
+            9,
+            1,
+        ),
+    },
+    Token {
+        kind: Class,
+        span: (
+            9,
+            7,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x92\xbb",
+        ),
+        span: (
+            9,
+            13,
+        ),
+    },
+    Token {
+        kind: Implements,
+        span: (
+            9,
+            18,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x94\x8a",
+        ),
+        span: (
+            9,
+            29,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            9,
+            34,
+        ),
+    },
+    Token {
+        kind: Public,
+        span: (
+            10,
+            3,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            10,
+            10,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x93\x9d",
+        ),
+        span: (
+            10,
+            19,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            10,
+            23,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "string",
+        ),
+        span: (
+            10,
+            24,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x93\x83",
+        ),
+        span: (
+            10,
+            31,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            10,
+            36,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            10,
+            37,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "void",
+        ),
+        span: (
+            10,
+            39,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            10,
+            44,
+        ),
+    },
+    Token {
+        kind: Print,
+        span: (
+            11,
+            5,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            11,
+            10,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x93\x83",
+        ),
+        span: (
+            11,
+            11,
+        ),
+    },
+    Token {
+        kind: Dot,
+        span: (
+            11,
+            17,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xe2\x86\xaa",
+        ),
+        span: (
+            11,
+            19,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            11,
+            22,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            11,
+            23,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            12,
+            3,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            13,
+            1,
+        ),
+    },
+    Token {
+        kind: Function,
+        span: (
+            15,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x9a\xaa",
+        ),
+        span: (
+            15,
+            10,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            15,
+            14,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            15,
+            15,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            15,
+            16,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "void",
+        ),
+        span: (
+            15,
+            18,
+        ),
+    },
+    Token {
+        kind: LeftBrace,
+        span: (
+            15,
+            23,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x92\xbb",
+        ),
+        span: (
+            16,
+            3,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            16,
+            9,
+        ),
+    },
+    Token {
+        kind: New,
+        span: (
+            16,
+            11,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x92\xbb",
+        ),
+        span: (
+            16,
+            15,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            16,
+            19,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            16,
+            20,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            16,
+            21,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x93\x84",
+        ),
+        span: (
+            17,
+            3,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            17,
+            9,
+        ),
+    },
+    Token {
+        kind: LiteralString(
+            "hello, world",
+        ),
+        span: (
+            17,
+            11,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            17,
+            25,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x92\xbb",
+        ),
+        span: (
+            18,
+            3,
+        ),
+    },
+    Token {
+        kind: Arrow,
+        span: (
+            18,
+            8,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x93\x9d",
+        ),
+        span: (
+            18,
+            10,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            18,
+            14,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x93\x83",
+        ),
+        span: (
+            18,
+            15,
+        ),
+    },
+    Token {
+        kind: Colon,
+        span: (
+            18,
+            19,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "\xf0\x9f\x93\x84",
+        ),
+        span: (
+            18,
+            21,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            18,
+            26,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            18,
+            27,
+        ),
+    },
+    Token {
+        kind: RightBrace,
+        span: (
+            19,
+            1,
+        ),
+    },
+    Token {
+        kind: Identifier(
+            "\xf0\x9f\x9a\xaa",
+        ),
+        span: (
+            21,
+            1,
+        ),
+    },
+    Token {
+        kind: LeftParen,
+        span: (
+            21,
+            5,
+        ),
+    },
+    Token {
+        kind: RightParen,
+        span: (
+            21,
+            6,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            21,
+            7,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "var\xef\xbf\xbd",
+        ),
+        span: (
+            23,
+            1,
+        ),
+    },
+    Token {
+        kind: Equals,
+        span: (
+            23,
+            9,
+        ),
+    },
+    Token {
+        kind: LiteralInteger(
+            "1",
+        ),
+        span: (
+            23,
+            11,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            23,
+            12,
+        ),
+    },
+    Token {
+        kind: Echo,
+        span: (
+            23,
+            14,
+        ),
+    },
+    Token {
+        kind: Variable(
+            "var\xef\xbf\xbd",
+        ),
+        span: (
+            23,
+            19,
+        ),
+    },
+    Token {
+        kind: SemiColon,
+        span: (
+            23,
+            26,
+        ),
+    },
+]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,11 +37,11 @@ fn test_fixtures() {
             continue;
         }
 
-        let code = std::fs::read_to_string(&code_file).unwrap();
+        let code = std::fs::read(&code_file).unwrap();
 
         if lex_err_file.exists() {
             let expected_error = std::fs::read_to_string(&lex_err_file).unwrap();
-            let error = LEXER.tokenize(code.as_bytes()).err().unwrap();
+            let error = LEXER.tokenize(&code).err().unwrap();
 
             assert_str_eq!(
                 expected_error.trim(),
@@ -60,7 +60,7 @@ fn test_fixtures() {
         );
 
         let expected_tokens = std::fs::read_to_string(&tokens_file).unwrap();
-        let tokens = LEXER.tokenize(code.as_bytes()).unwrap();
+        let tokens = LEXER.tokenize(&code).unwrap();
 
         assert_str_eq!(
             expected_tokens.trim(),


### PR DESCRIPTION
Not much of a performance gain, but it makes lexer state easier to work with.

benchmarks:

before:

```
  Time (mean ± σ):      2.519 s ±  0.017 s    [User: 2.611 s, System: 0.225 s]
  Range (min … max):    2.501 s …  2.551 s    10 runs
```

after:

```
  Time (mean ± σ):      2.451 s ±  0.007 s    [User: 2.561 s, System: 0.190 s]
  Range (min … max):    2.443 s …  2.462 s    10 runs
```
