### PR TITLE
fix: better heredoc/nowdoc implementation

### DIFF
--- a/src/lexer/state.rs
+++ b/src/lexer/state.rs
@@ -5,6 +5,9 @@ use crate::lexer::error::SyntaxError;
 use crate::lexer::error::SyntaxResult;
 use crate::lexer::source::Source;
 
+use super::token::DocStringIndentationAmount;
+use super::token::DocStringIndentationKind;
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 pub enum DocStringKind {
     Heredoc,
@@ -18,7 +21,12 @@ pub enum StackFrame {
     Halted,
     DoubleQuote,
     ShellExec,
-    DocString(DocStringKind, ByteString),
+    DocString(
+        DocStringKind,
+        ByteString,
+        DocStringIndentationKind,
+        DocStringIndentationAmount,
+    ),
     LookingForVarname,
     LookingForProperty,
     VarOffset,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -11,10 +11,14 @@ pub enum OpenTagKind {
     Full,
 }
 
+pub type DocStringIndentationAmount = usize;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DocStringIndentationKind {
     Space,
     Tab,
+    None,
+    Both,
 }
 
 impl From<u8> for DocStringIndentationKind {
@@ -32,6 +36,7 @@ impl From<DocStringIndentationKind> for u8 {
         match kind {
             DocStringIndentationKind::Space => b' ',
             DocStringIndentationKind::Tab => b'\t',
+            _ => unreachable!(),
         }
     }
 }
@@ -43,7 +48,7 @@ pub enum TokenKind {
     Parent,
     Backtick,
     StartDocString(ByteString, DocStringKind),
-    EndDocString(ByteString, Option<DocStringIndentationKind>, usize),
+    EndDocString(ByteString, DocStringIndentationKind, usize),
     From,
     Print,
     Dollar,

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,5 +1,7 @@
 use crate::expect_token;
 use crate::expected_token_err;
+use crate::lexer::error::SyntaxError;
+use crate::lexer::token::DocStringIndentationKind;
 use crate::lexer::token::TokenKind;
 use crate::lexer::DocStringKind;
 use crate::parser::ast;
@@ -792,6 +794,7 @@ fn shell_exec(state: &mut State) -> ParseResult<Expression> {
 
 #[inline(always)]
 fn doc_string(state: &mut State, kind: DocStringKind) -> ParseResult<Expression> {
+    let span = state.current.span;
     state.next();
 
     Ok(match kind {
@@ -813,19 +816,65 @@ fn doc_string(state: &mut State, kind: DocStringKind) -> ParseResult<Expression>
 
             state.next();
 
-            // FIXME: Can we move this logic above into the loop, by peeking ahead in
-            //        the token stream for the EndHeredoc? Might be more performant.
-            if let Some(indentation_type) = indentation_type {
-                let search_char: u8 = indentation_type.into();
+            let mut new_line = true;
+            if indentation_type != DocStringIndentationKind::None {
+                let indentation_char: u8 = indentation_type.into();
 
                 for part in parts.iter_mut() {
+                    // We only need to strip and validate indentation
+                    // for individual lines, so we can skip checks if
+                    // we know we're not on a new line.
+                    if !new_line {
+                        continue;
+                    }
+
                     match part {
                         StringPart::Const(bytes) => {
-                            for _ in 0..indentation_amount {
-                                if bytes.starts_with(&[search_char]) {
-                                    bytes.remove(0);
-                                }
+                            // 1. If this line doesn't start with any whitespace,
+                            //    we can return an error early because we know
+                            //    the label was indented.
+                            if !bytes.starts_with(&[b' ']) && !bytes.starts_with(&[b'\t']) {
+                                return Err(ParseError::SyntaxError(
+                                    SyntaxError::InvalidDocBodyIndentationLevel(
+                                        indentation_amount,
+                                        span,
+                                    ),
+                                ));
                             }
+
+                            // 2. If this line doesn't start with the correct
+                            //    type of whitespace, we can also return an error.
+                            if !bytes.starts_with(&[indentation_char]) {
+                                return Err(ParseError::SyntaxError(
+                                    SyntaxError::InvalidDocIndentation(span),
+                                ));
+                            }
+
+                            // 3. We now know that the whitespace at the start of
+                            //    this line is correct, so we need to check that the
+                            //    amount of whitespace is correct too. In this case,
+                            //    the amount of whitespace just needs to be at least
+                            //    the same, so we can create a vector containing the
+                            //    minimum and check using `starts_with()`.
+                            let expected_whitespace_buffer =
+                                vec![indentation_char; indentation_amount];
+                            if !bytes.starts_with(&expected_whitespace_buffer) {
+                                return Err(ParseError::SyntaxError(
+                                    SyntaxError::InvalidDocBodyIndentationLevel(
+                                        indentation_amount,
+                                        span,
+                                    ),
+                                ));
+                            }
+
+                            // 4. All of the above checks have passed, so we know
+                            //    there are no more possible errors. Let's now
+                            //    strip the leading whitespace accordingly.
+                            *bytes = bytes
+                                .strip_prefix(&expected_whitespace_buffer[..])
+                                .unwrap()
+                                .into();
+                            new_line = bytes.ends_with(&[b'\n']);
                         }
                         _ => continue,
                     }
@@ -835,31 +884,71 @@ fn doc_string(state: &mut State, kind: DocStringKind) -> ParseResult<Expression>
             Expression::Heredoc { parts }
         }
         DocStringKind::Nowdoc => {
-            // FIXME: This feels hacky. We should probably produce different tokens from the lexer
-            //        but since I already had the logic in place for parsing heredocs, this was
-            //        the fastest way to get nowdocs working too.
-            let mut s = expect_token!([
-                    TokenKind::StringPart(s) => s
-                ], state, "constant string");
+            let mut string_part = expect_token!([
+                TokenKind::StringPart(s) => s,
+            ], state, "constant string");
 
-            let (indentation_type, indentation_amount) = expect_token!([
-                    TokenKind::EndDocString(_, indentation_type, indentation_amount) => (indentation_type, indentation_amount)
-                ], state, "label");
+            let (indentation_type, indentation_amount) = match state.current.kind {
+                TokenKind::EndDocString(_, indentation_type, indentation_amount) => {
+                    (indentation_type, indentation_amount)
+                }
+                _ => unreachable!(),
+            };
 
-            // FIXME: Hacky code, but it's late and I want to get this done.
-            if let Some(indentation_type) = indentation_type {
-                let search_char: u8 = indentation_type.into();
-                let mut lines = s
+            state.next();
+
+            if indentation_type != DocStringIndentationKind::None {
+                let indentation_char: u8 = indentation_type.into();
+
+                let mut lines = string_part
                     .split(|b| *b == b'\n')
                     .map(|s| s.to_vec())
                     .collect::<Vec<Vec<u8>>>();
+
                 for line in lines.iter_mut() {
-                    for _ in 0..indentation_amount {
-                        if line.starts_with(&[search_char]) {
-                            line.remove(0);
-                        }
+                    if line.is_empty() {
+                        continue;
                     }
+
+                    // 1. If this line doesn't start with any whitespace,
+                    //    we can return an error early because we know
+                    //    the label was indented.
+                    if !line.starts_with(&[b' ']) && !line.starts_with(&[b'\t']) {
+                        return Err(ParseError::SyntaxError(
+                            SyntaxError::InvalidDocBodyIndentationLevel(indentation_amount, span),
+                        ));
+                    }
+
+                    // 2. If this line doesn't start with the correct
+                    //    type of whitespace, we can also return an error.
+                    if !line.starts_with(&[indentation_char]) {
+                        return Err(ParseError::SyntaxError(SyntaxError::InvalidDocIndentation(
+                            span,
+                        )));
+                    }
+
+                    // 3. We now know that the whitespace at the start of
+                    //    this line is correct, so we need to check that the
+                    //    amount of whitespace is correct too. In this case,
+                    //    the amount of whitespace just needs to be at least
+                    //    the same, so we can create a vector containing the
+                    //    minimum and check using `starts_with()`.
+                    let expected_whitespace_buffer = vec![indentation_char; indentation_amount];
+                    if !line.starts_with(&expected_whitespace_buffer) {
+                        return Err(ParseError::SyntaxError(
+                            SyntaxError::InvalidDocBodyIndentationLevel(indentation_amount, span),
+                        ));
+                    }
+
+                    // 4. All of the above checks have passed, so we know
+                    //    there are no more possible errors. Let's now
+                    //    strip the leading whitespace accordingly.
+                    *line = line
+                        .strip_prefix(&expected_whitespace_buffer[..])
+                        .unwrap()
+                        .into();
                 }
+
                 let mut bytes = Vec::new();
                 for (i, line) in lines.iter().enumerate() {
                     bytes.extend(line);
@@ -867,10 +956,10 @@ fn doc_string(state: &mut State, kind: DocStringKind) -> ParseResult<Expression>
                         bytes.push(b'\n');
                     }
                 }
-                s = bytes.into();
+                string_part = bytes.into();
             }
 
-            Expression::Nowdoc { value: s }
+            Expression::Nowdoc { value: string_part }
         }
     })
 }

--- a/src/parser/internal/loops.rs
+++ b/src/parser/internal/loops.rs
@@ -1,11 +1,11 @@
 use crate::lexer::token::TokenKind;
+use crate::parser;
 use crate::parser::ast::Statement;
 use crate::parser::error::ParseResult;
 use crate::parser::expressions;
 use crate::parser::internal::blocks;
 use crate::parser::internal::utils;
 use crate::parser::state::State;
-use crate::parser;
 
 pub fn foreach_loop(state: &mut State) -> ParseResult<Statement> {
     utils::skip(state, TokenKind::Foreach)?;

--- a/tests/fixtures/0226/lexer-error.txt
+++ b/tests/fixtures/0226/lexer-error.txt
@@ -1,1 +1,0 @@
-InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/fixtures/0226/parser-error.txt
+++ b/tests/fixtures/0226/parser-error.txt
@@ -1,0 +1,1 @@
+SyntaxError(InvalidDocBodyIndentationLevel(4, (3, 1))) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 3

--- a/tests/fixtures/0227/lexer-error.txt
+++ b/tests/fixtures/0227/lexer-error.txt
@@ -1,1 +1,0 @@
-InvalidDocIndentation((5, 1)) -> Syntax Error: Invalid indentation - cannot use tabs and spaces on line 5

--- a/tests/fixtures/0227/parser-error.txt
+++ b/tests/fixtures/0227/parser-error.txt
@@ -1,0 +1,1 @@
+SyntaxError(InvalidDocIndentation((3, 1))) -> Syntax Error: Invalid indentation - cannot use tabs and spaces on line 3

--- a/tests/fixtures/0233/lexer-error.txt
+++ b/tests/fixtures/0233/lexer-error.txt
@@ -1,1 +1,0 @@
-InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/fixtures/0233/parser-error.txt
+++ b/tests/fixtures/0233/parser-error.txt
@@ -1,0 +1,1 @@
+SyntaxError(InvalidDocBodyIndentationLevel(4, (3, 1))) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 3

--- a/tests/fixtures/0234/lexer-error.txt
+++ b/tests/fixtures/0234/lexer-error.txt
@@ -1,1 +1,0 @@
-InvalidDocBodyIndentationLevel(4, (5, 5)) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 5

--- a/tests/fixtures/0234/parser-error.txt
+++ b/tests/fixtures/0234/parser-error.txt
@@ -1,0 +1,1 @@
+SyntaxError(InvalidDocBodyIndentationLevel(4, (3, 1))) -> Syntax Error: Invalid body indentation level - expecting an indentation level of at least 4 on line 3


### PR DESCRIPTION
Closes #161.

I'm returning `SyntaxError`s from the parser, but don't really care at this point. Handling the intricacies of heredocs & nowdocs in the parser is SO much easier than carrying state around inside of a `StackFrame` and having to mess with the borrow checker.

I ran the Symfony and Laravel third party tests and there's no sign of heredoc/nowdoc errors so I'm taking that as a win.

I'm more or less praying that it's all correct and that I never have to come back to this, lol. In theory though, this code with the comments is much easier to debug going forward. Debugging errors in the lexer before was impossible, at least now all the heavy lifting is done in the parser.