### PR TITLE
fix: fix usage of reserved keywords as label names, and identifiers

### DIFF
--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -51,6 +51,7 @@ pub enum ParseError {
     CannotMixKeyedAndUnkeyedEntries(Span),
     CannotUsePositionalArgumentAfterNamedArgument(Span),
     CannotUseReservedKeywordAsATypeName(String, Span),
+    CannotUseReservedKeywordAsAGoToLabel(String, Span),
 }
 
 impl From<SyntaxError> for ParseError {
@@ -129,7 +130,8 @@ impl Display for ParseError {
             Self::CannotAssignReferenceToNonReferencableValue(span) => write!(f, "Parse Error: cannot assign reference to non-referencable value on line {} column {}", span.0, span.1),
             Self::CannotMixKeyedAndUnkeyedEntries(span) => write!(f, "Parse Error: cannot mix keyed and un-keyed entries on line {}", span.0),
             Self::CannotUsePositionalArgumentAfterNamedArgument(span) => write!(f, "Parse Error: cannot use positional argument after named argument on line {} column {}", span.0, span.1),
-            Self::CannotUseReservedKeywordAsATypeName(ty, span) => write!(f, "Parse Error: cannot use `{}` as a type name as it is reserved on line {} column {}", ty, span.0, span.1)
+            Self::CannotUseReservedKeywordAsATypeName(ty, span) => write!(f, "Parse Error: cannot use `{}` as a type name as it is reserved on line {} column {}", ty, span.0, span.1),
+            Self::CannotUseReservedKeywordAsAGoToLabel(ty, span) => write!(f, "Parse Error: cannot use `{}` as a goto label as it is reserved on line {} column {}", ty, span.0, span.1),
         }
     }
 }

--- a/src/parser/internal/goto.rs
+++ b/src/parser/internal/goto.rs
@@ -6,7 +6,7 @@ use crate::parser::internal::utils;
 use crate::parser::state::State;
 
 pub fn label_statement(state: &mut State) -> ParseResult<Statement> {
-    let label = identifiers::identifier(state)?;
+    let label = identifiers::label_identifier(state)?;
 
     utils::skip_colon(state)?;
 
@@ -16,7 +16,7 @@ pub fn label_statement(state: &mut State) -> ParseResult<Statement> {
 pub fn goto_statement(state: &mut State) -> ParseResult<Statement> {
     utils::skip(state, TokenKind::Goto)?;
 
-    let label = identifiers::identifier(state)?;
+    let label = identifiers::label_identifier(state)?;
 
     utils::skip_semicolon(state)?;
 

--- a/src/parser/internal/identifiers.rs
+++ b/src/parser/internal/identifiers.rs
@@ -52,6 +52,36 @@ pub fn type_identifier(state: &mut State) -> ParseResult<SimpleIdentifier> {
     }
 }
 
+/// Expect an unqualified identifier such as Foo or Bar for a class, interface, trait, or an enum name.
+pub fn label_identifier(state: &mut State) -> ParseResult<SimpleIdentifier> {
+    match state.current.kind.clone() {
+        TokenKind::Identifier(name) => {
+            let span = state.current.span;
+
+            state.next();
+
+            Ok(SimpleIdentifier { span, name })
+        }
+        TokenKind::Enum | TokenKind::From => {
+            let span = state.current.span;
+            let name = state.current.kind.to_string().into();
+
+            state.next();
+
+            Ok(SimpleIdentifier { span, name })
+        }
+        t if is_reserved_identifier(&t) => Err(ParseError::CannotUseReservedKeywordAsAGoToLabel(
+            state.current.kind.to_string(),
+            state.current.span,
+        )),
+        _ => Err(ParseError::ExpectedToken(
+            vec!["an identifier".to_owned()],
+            Some(state.current.kind.to_string()),
+            state.current.span,
+        )),
+    }
+}
+
 /// Expect an unqualified identifier such as Foo or Bar.
 pub fn identifier(state: &mut State) -> ParseResult<SimpleIdentifier> {
     if let TokenKind::Identifier(name) = state.current.kind.clone() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -115,7 +115,13 @@ fn statement(state: &mut State) -> ParseResult<Statement> {
             TokenKind::Class => classes::parse(state)?,
             TokenKind::Interface => interfaces::parse(state)?,
             TokenKind::Trait => traits::parse(state)?,
-            TokenKind::Enum if state.peek.kind != TokenKind::LeftParen => enums::parse(state)?,
+            TokenKind::Enum
+                if state.peek.kind != TokenKind::LeftParen
+                    && state.peek.kind != TokenKind::DoubleColon
+                    && state.peek.kind != TokenKind::Colon =>
+            {
+                enums::parse(state)?
+            }
             TokenKind::Function
                 if identifiers::is_identifier_maybe_soft_reserved(&state.peek.kind)
                     || state.peek.kind == TokenKind::Ampersand =>
@@ -163,7 +169,13 @@ fn statement(state: &mut State) -> ParseResult<Statement> {
             TokenKind::Class => classes::parse(state)?,
             TokenKind::Interface => interfaces::parse(state)?,
             TokenKind::Trait => traits::parse(state)?,
-            TokenKind::Enum if state.peek.kind != TokenKind::LeftParen => enums::parse(state)?,
+            TokenKind::Enum
+                if state.peek.kind != TokenKind::LeftParen
+                    && state.peek.kind != TokenKind::DoubleColon
+                    && state.peek.kind != TokenKind::Colon =>
+            {
+                enums::parse(state)?
+            }
             TokenKind::Function
                 if identifiers::is_identifier_maybe_soft_reserved(&state.peek.kind)
                     || state.peek.kind == TokenKind::Ampersand =>
@@ -194,7 +206,10 @@ fn statement(state: &mut State) -> ParseResult<Statement> {
                 }
             }
             TokenKind::Goto => goto::goto_statement(state)?,
-            TokenKind::Identifier(_) if state.peek.kind == TokenKind::Colon => {
+            token
+                if identifiers::is_identifier_maybe_reserved(token)
+                    && state.peek.kind == TokenKind::Colon =>
+            {
                 goto::label_statement(state)?
             }
             TokenKind::Declare => {

--- a/tests/fixtures/0285-reserved-type-name/ast.txt
+++ b/tests/fixtures/0285-reserved-type-name/ast.txt
@@ -263,4 +263,430 @@
             body: [],
         },
     ),
+    Expression {
+        expr: Call {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            16,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: Call {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            17,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: Call {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            19,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: Call {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            20,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: StaticMethodCall {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            22,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            method: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            22,
+                            7,
+                        ),
+                        name: "foo",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: StaticMethodCall {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            23,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            method: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            23,
+                            7,
+                        ),
+                        name: "foo",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: StaticMethodCall {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            25,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            method: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            25,
+                            7,
+                        ),
+                        name: "foo",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: StaticMethodCall {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            26,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            method: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            26,
+                            7,
+                        ),
+                        name: "foo",
+                    },
+                ),
+            ),
+            args: [],
+        },
+    },
+    Expression {
+        expr: Instanceof {
+            left: Variable(
+                SimpleVariable(
+                    SimpleVariable {
+                        span: (
+                            28,
+                            1,
+                        ),
+                        name: "a",
+                    },
+                ),
+            ),
+            span: (
+                28,
+                4,
+            ),
+            right: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            28,
+                            15,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+        },
+    },
+    Expression {
+        expr: Instanceof {
+            left: Variable(
+                SimpleVariable(
+                    SimpleVariable {
+                        span: (
+                            29,
+                            1,
+                        ),
+                        name: "a",
+                    },
+                ),
+            ),
+            span: (
+                29,
+                4,
+            ),
+            right: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            29,
+                            15,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+        },
+    },
+    Expression {
+        expr: Instanceof {
+            left: Variable(
+                SimpleVariable(
+                    SimpleVariable {
+                        span: (
+                            31,
+                            1,
+                        ),
+                        name: "a",
+                    },
+                ),
+            ),
+            span: (
+                31,
+                4,
+            ),
+            right: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            31,
+                            15,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+        },
+    },
+    Expression {
+        expr: Instanceof {
+            left: Variable(
+                SimpleVariable(
+                    SimpleVariable {
+                        span: (
+                            32,
+                            1,
+                        ),
+                        name: "a",
+                    },
+                ),
+            ),
+            span: (
+                32,
+                4,
+            ),
+            right: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            32,
+                            15,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+        },
+    },
+    Expression {
+        expr: ConstFetch {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            34,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            constant: SimpleIdentifier {
+                span: (
+                    34,
+                    7,
+                ),
+                name: "class",
+            },
+        },
+    },
+    Expression {
+        expr: ConstFetch {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            35,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            constant: SimpleIdentifier {
+                span: (
+                    35,
+                    7,
+                ),
+                name: "class",
+            },
+        },
+    },
+    Expression {
+        expr: ConstFetch {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            36,
+                            1,
+                        ),
+                        name: "enum",
+                    },
+                ),
+            ),
+            constant: SimpleIdentifier {
+                span: (
+                    36,
+                    7,
+                ),
+                name: "class",
+            },
+        },
+    },
+    Expression {
+        expr: ConstFetch {
+            target: Identifier(
+                SimpleIdentifier(
+                    SimpleIdentifier {
+                        span: (
+                            37,
+                            1,
+                        ),
+                        name: "from",
+                    },
+                ),
+            ),
+            constant: SimpleIdentifier {
+                span: (
+                    37,
+                    7,
+                ),
+                name: "class",
+            },
+        },
+    },
+    Label {
+        label: SimpleIdentifier {
+            span: (
+                39,
+                1,
+            ),
+            name: "from",
+        },
+    },
+    Expression {
+        expr: LiteralInteger {
+            i: "12",
+        },
+    },
+    Goto {
+        label: SimpleIdentifier {
+            span: (
+                41,
+                6,
+            ),
+            name: "from",
+        },
+    },
+    Label {
+        label: SimpleIdentifier {
+            span: (
+                43,
+                1,
+            ),
+            name: "enum",
+        },
+    },
+    Expression {
+        expr: LiteralInteger {
+            i: "123",
+        },
+    },
+    Goto {
+        label: SimpleIdentifier {
+            span: (
+                45,
+                6,
+            ),
+            name: "enum",
+        },
+    },
 ]

--- a/tests/fixtures/0285-reserved-type-name/code.php
+++ b/tests/fixtures/0285-reserved-type-name/code.php
@@ -12,3 +12,34 @@ interface from {}
 trait from {}
 enum from {}
 function from(): from {}
+
+from();
+enum();
+
+frOm();
+eNum();
+
+Enum::foo();
+From::foo();
+
+enum::foo();
+from::foo();
+
+$a instanceof Enum;
+$a instanceof FroM;
+
+$a instanceof enum;
+$a instanceof from;
+
+Enum::class;
+From::class;
+enum::class;
+from::class;
+
+from: 12;
+
+goto from;
+
+enum: 123;
+
+goto enum;

--- a/tests/fixtures/0286-reserved-type-name/code.php
+++ b/tests/fixtures/0286-reserved-type-name/code.php
@@ -1,0 +1,4 @@
+<?php 
+
+
+class interface {}

--- a/tests/fixtures/0286-reserved-type-name/parser-error.txt
+++ b/tests/fixtures/0286-reserved-type-name/parser-error.txt
@@ -1,0 +1,1 @@
+CannotUseReservedKeywordAsATypeName("interface", (4, 7)) -> Parse Error: cannot use `interface` as a type name as it is reserved on line 4 column 7

--- a/tests/fixtures/0287-reserved-label-name/code.php
+++ b/tests/fixtures/0287-reserved-label-name/code.php
@@ -1,0 +1,3 @@
+<?php 
+
+foreach: 

--- a/tests/fixtures/0287-reserved-label-name/parser-error.txt
+++ b/tests/fixtures/0287-reserved-label-name/parser-error.txt
@@ -1,0 +1,1 @@
+CannotUseReservedKeywordAsAGoToLabel("foreach", (3, 1)) -> Parse Error: cannot use `foreach` as a goto label as it is reserved on line 3 column 1

--- a/tests/fixtures/0288-reserved-label-name/code.php
+++ b/tests/fixtures/0288-reserved-label-name/code.php
@@ -1,0 +1,3 @@
+<?php 
+
+goto interface;

--- a/tests/fixtures/0288-reserved-label-name/parser-error.txt
+++ b/tests/fixtures/0288-reserved-label-name/parser-error.txt
@@ -1,0 +1,1 @@
+CannotUseReservedKeywordAsAGoToLabel("interface", (3, 6)) -> Parse Error: cannot use `interface` as a goto label as it is reserved on line 3 column 6


### PR DESCRIPTION
this fixes bunch of cases regarding the usage of reserved keywords as identifiers and label names, also adds a good error message for when a reserved keyword is used for a label.