### PR TITLE
fix multiple parse errors, and error for magic methods on enums

### DIFF
--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -53,6 +53,7 @@ pub enum ParseError {
     CannotUseReservedKeywordAsATypeName(String, Span),
     CannotUseReservedKeywordAsAGoToLabel(String, Span),
     CannotUseReservedKeywordAsAConstantName(String, Span),
+    EnumMayNotIncludesMagicMethod(String, String, Span),
 }
 
 impl From<SyntaxError> for ParseError {
@@ -134,6 +135,7 @@ impl Display for ParseError {
             Self::CannotUseReservedKeywordAsATypeName(ty, span) => write!(f, "Parse Error: cannot use `{}` as a type name as it is reserved on line {} column {}", ty, span.0, span.1),
             Self::CannotUseReservedKeywordAsAGoToLabel(ty, span) => write!(f, "Parse Error: cannot use `{}` as a goto label as it is reserved on line {} column {}", ty, span.0, span.1),
             Self::CannotUseReservedKeywordAsAConstantName(ty, span) => write!(f, "Parse Error: cannot use `{}` as a constant name as it is reserved on line {} column {}", ty, span.0, span.1),
+            Self::EnumMayNotIncludesMagicMethod(ty, method, span) => write!(f, "Parse Error: Enum `{}` may not include magic method `{}` on line {} column {}", ty, method, span.0, span.1),
         }
     }
 }

--- a/src/parser/internal/classes.rs
+++ b/src/parser/internal/classes.rs
@@ -1,3 +1,4 @@
+use crate::lexer::token::Span;
 use crate::lexer::token::TokenKind;
 use crate::parser::ast::classes::AnonymousClass;
 use crate::parser::ast::classes::Class;
@@ -91,8 +92,11 @@ pub fn parse(state: &mut State) -> ParseResult<Statement> {
     }))
 }
 
-pub fn parse_anonymous(state: &mut State) -> ParseResult<Expression> {
-    let span = utils::skip(state, TokenKind::New)?;
+pub fn parse_anonymous(state: &mut State, span: Option<Span>) -> ParseResult<Expression> {
+    let span = match span {
+        Some(span) => span,
+        None => utils::skip(state, TokenKind::New)?,
+    };
 
     attributes::gather_attributes(state)?;
 

--- a/src/parser/internal/parameters.rs
+++ b/src/parser/internal/parameters.rs
@@ -68,9 +68,9 @@ pub fn function_parameter_list(state: &mut State) -> Result<FunctionParameterLis
         });
 
         state.skip_comments();
-
         if state.current.kind == TokenKind::Comma {
             state.next();
+            state.skip_comments();
         } else {
             break;
         }
@@ -219,9 +219,9 @@ pub fn method_parameter_list(state: &mut State) -> Result<MethodParameterList, P
         });
 
         state.skip_comments();
-
         if state.current.kind == TokenKind::Comma {
             state.next();
+            state.skip_comments();
         } else {
             break;
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,7 +5,6 @@ use crate::parser::ast::comments::Comment;
 use crate::parser::ast::comments::CommentFormat;
 use crate::parser::ast::variables::Variable;
 use crate::parser::ast::{DeclareItem, Expression, Program, Statement, StaticVar};
-use crate::parser::error::ParseError;
 use crate::parser::error::ParseResult;
 use crate::parser::internal::attributes;
 use crate::parser::internal::blocks;
@@ -151,13 +150,9 @@ fn statement(state: &mut State) -> ParseResult<Statement> {
                     functions::function(state)?
                 }
             }
-            _ => {
-                // Note, we can get attributes and know their span, maybe use that in the
-                // error in the future?
-                return Err(ParseError::ExpectedItemDefinitionAfterAttributes(
-                    state.current.span,
-                ));
-            }
+            _ => Statement::Expression {
+                expr: expressions::attributes(state)?,
+            },
         }
     } else {
         match &state.current.kind {

--- a/tests/fixtures/0297-enum-serialize/code.php
+++ b/tests/fixtures/0297-enum-serialize/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithSerialize {
+    public function __serialize() {}
+}

--- a/tests/fixtures/0297-enum-serialize/parser-error.txt
+++ b/tests/fixtures/0297-enum-serialize/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithSerialize", "__serialize", (4, 21)) -> Parse Error: Enum `EnumWithSerialize` may not include magic method `__serialize` on line 4 column 21

--- a/tests/fixtures/0298-enum-unserialize/code.php
+++ b/tests/fixtures/0298-enum-unserialize/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithUnserialize {
+    public function __unserialize(array $data) {}
+}

--- a/tests/fixtures/0298-enum-unserialize/parser-error.txt
+++ b/tests/fixtures/0298-enum-unserialize/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithUnserialize", "__unserialize", (4, 21)) -> Parse Error: Enum `EnumWithUnserialize` may not include magic method `__unserialize` on line 4 column 21

--- a/tests/fixtures/0299-enum-get/code.php
+++ b/tests/fixtures/0299-enum-get/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithGet {
+    public function __get($v) {}
+}

--- a/tests/fixtures/0299-enum-get/parser-error.txt
+++ b/tests/fixtures/0299-enum-get/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithGet", "__get", (4, 21)) -> Parse Error: Enum `EnumWithGet` may not include magic method `__get` on line 4 column 21

--- a/tests/fixtures/0300-enum-set/code.php
+++ b/tests/fixtures/0300-enum-set/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithSet {
+    public function __set($k, $v) {}
+}

--- a/tests/fixtures/0300-enum-set/parser-error.txt
+++ b/tests/fixtures/0300-enum-set/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithSet", "__set", (4, 21)) -> Parse Error: Enum `EnumWithSet` may not include magic method `__set` on line 4 column 21

--- a/tests/fixtures/0301-enum-call/code.php
+++ b/tests/fixtures/0301-enum-call/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithCall {
+    public function __call($k, $v) {}
+}

--- a/tests/fixtures/0301-enum-call/parser-error.txt
+++ b/tests/fixtures/0301-enum-call/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithCall", "__call", (4, 21)) -> Parse Error: Enum `EnumWithCall` may not include magic method `__call` on line 4 column 21

--- a/tests/fixtures/0302-enum-call-static/code.php
+++ b/tests/fixtures/0302-enum-call-static/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithCallStatic {
+    public static function __callStatic($k, $v) {}
+}

--- a/tests/fixtures/0302-enum-call-static/parser-error.txt
+++ b/tests/fixtures/0302-enum-call-static/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithCallStatic", "__callStatic", (4, 28)) -> Parse Error: Enum `EnumWithCallStatic` may not include magic method `__callStatic` on line 4 column 28

--- a/tests/fixtures/0303-enum-invoke/code.php
+++ b/tests/fixtures/0303-enum-invoke/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithInvoke {
+    public function __invoke() {}
+}

--- a/tests/fixtures/0303-enum-invoke/parser-error.txt
+++ b/tests/fixtures/0303-enum-invoke/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithInvoke", "__invoke", (4, 21)) -> Parse Error: Enum `EnumWithInvoke` may not include magic method `__invoke` on line 4 column 21

--- a/tests/fixtures/0304-enum-dtor/code.php
+++ b/tests/fixtures/0304-enum-dtor/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithDtor {
+    public function __destruct() {}
+}

--- a/tests/fixtures/0304-enum-dtor/parser-error.txt
+++ b/tests/fixtures/0304-enum-dtor/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithDtor", "__destruct", (4, 21)) -> Parse Error: Enum `EnumWithDtor` may not include magic method `__destruct` on line 4 column 21

--- a/tests/fixtures/0305-enum-sleep/code.php
+++ b/tests/fixtures/0305-enum-sleep/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithSleep {
+    public function __sleep() {}
+}

--- a/tests/fixtures/0305-enum-sleep/parser-error.txt
+++ b/tests/fixtures/0305-enum-sleep/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithSleep", "__sleep", (4, 21)) -> Parse Error: Enum `EnumWithSleep` may not include magic method `__sleep` on line 4 column 21

--- a/tests/fixtures/0306-enum-wakeup/code.php
+++ b/tests/fixtures/0306-enum-wakeup/code.php
@@ -1,0 +1,5 @@
+<?php
+
+enum EnumWithWakeUp {
+    public function __wakeup() {}
+}

--- a/tests/fixtures/0306-enum-wakeup/parser-error.txt
+++ b/tests/fixtures/0306-enum-wakeup/parser-error.txt
@@ -1,0 +1,1 @@
+EnumMayNotIncludesMagicMethod("EnumWithWakeUp", "__wakeup", (4, 21)) -> Parse Error: Enum `EnumWithWakeUp` may not include magic method `__wakeup` on line 4 column 21

--- a/tests/fixtures/0307-uses-commented/ast.txt
+++ b/tests/fixtures/0307-uses-commented/ast.txt
@@ -1,0 +1,108 @@
+[
+    Use {
+        uses: [
+            Use {
+                name: SimpleIdentifier {
+                    span: (
+                        4,
+                        13,
+                    ),
+                    name: "foo",
+                },
+                alias: None,
+            },
+        ],
+        kind: Normal,
+    },
+    Use {
+        uses: [
+            Use {
+                name: SimpleIdentifier {
+                    span: (
+                        5,
+                        13,
+                    ),
+                    name: "bar",
+                },
+                alias: None,
+            },
+        ],
+        kind: Normal,
+    },
+    GroupUse {
+        prefix: SimpleIdentifier {
+            span: (
+                6,
+                5,
+            ),
+            name: "bar\",
+        },
+        kind: Normal,
+        uses: [
+            Use {
+                name: SimpleIdentifier {
+                    span: (
+                        7,
+                        13,
+                    ),
+                    name: "w",
+                },
+                alias: Some(
+                    SimpleIdentifier {
+                        span: (
+                            7,
+                            36,
+                        ),
+                        name: "b",
+                    },
+                ),
+            },
+            Use {
+                name: SimpleIdentifier {
+                    span: (
+                        8,
+                        13,
+                    ),
+                    name: "z",
+                },
+                alias: None,
+            },
+        ],
+    },
+    Function(
+        Function {
+            start: (
+                12,
+                1,
+            ),
+            end: (
+                12,
+                23,
+            ),
+            name: SimpleIdentifier {
+                span: (
+                    12,
+                    10,
+                ),
+                name: "qux",
+            },
+            attributes: [],
+            parameters: FunctionParameterList {
+                start: (
+                    12,
+                    13,
+                ),
+                end: (
+                    12,
+                    15,
+                ),
+                members: [],
+            },
+            return_type: Some(
+                Void,
+            ),
+            by_ref: false,
+            body: [],
+        },
+    ),
+]

--- a/tests/fixtures/0307-uses-commented/code.php
+++ b/tests/fixtures/0307-uses-commented/code.php
@@ -1,0 +1,12 @@
+<?php
+
+/* a */
+use /* a */ foo; /* a */
+use /* a */ bar /* a */; /* a */ 
+use bar\ {
+   /* a */  w /* a */  as /* a */  b, /* a */ 
+   /* a */  z, /* a */ 
+} /* a */;
+/* a */
+
+function qux(): void {}

--- a/tests/third_party_tests.rs
+++ b/tests/third_party_tests.rs
@@ -133,7 +133,32 @@ fn phpstan_bin() {
 
 #[test]
 fn phpstan_src() {
-    test_repository("phpstan-src", "https://github.com/phpstan/phpstan-src", &[]);
+    test_repository(
+        "phpstan-src",
+        "https://github.com/phpstan/phpstan-src",
+        &[
+            "tests/PHPStan/Rules/Classes/data/invalid-promoted-properties.php",
+            "tests/PHPStan/Rules/Classes/data/trait-use-error.php",
+            "tests/PHPStan/Analyser/data/multipleParseErrors.php",
+            "tests/PHPStan/Analyser/data/parse-error.php",
+            "tests/PHPStan/Levels/data/namedArguments.php",
+            "tests/PHPStan/Rules/Classes/data/enum-sanity.php",
+            "tests/PHPStan/Rules/Classes/data/instanceof.php",
+            "tests/PHPStan/Rules/Functions/data/arrow-function-intersection-types.php",
+            "tests/PHPStan/Rules/Functions/data/closure-intersection-types.php",
+            "tests/PHPStan/Rules/Functions/data/intersection-types.php",
+            "tests/PHPStan/Rules/Methods/data/abstract-method.php",
+            "tests/PHPStan/Rules/Methods/data/call-method-in-enum.php",
+            "tests/PHPStan/Rules/Methods/data/intersection-types.php",
+            "tests/PHPStan/Rules/Methods/data/missing-method-impl.php",
+            "tests/PHPStan/Rules/Methods/data/named-arguments.php",
+            "tests/PHPStan/Rules/Methods/data/named-arguments.php",
+            "tests/PHPStan/Rules/Functions/data/closure-typehints.php",
+            "tests/PHPStan/Rules/Properties/data/intersection-types.php",
+            "tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc-and-native.php",
+            "tests/PHPStan/Rules/Properties/data/read-only-property.php",
+        ],
+    );
 }
 
 #[test]
@@ -272,7 +297,11 @@ fn doctrine_dbal() {
 
 #[test]
 fn phpunit() {
-    test_repository("phpunit", "https://github.com/phpunit/phpunit", &[]);
+    test_repository(
+        "phpunit",
+        "https://github.com/sebastianbergmann/phpunit",
+        &[],
+    );
 }
 
 fn test_repository(name: &str, repository: &str, ignore: &[&str]) {


### PR DESCRIPTION
fixes multiple issues regarding comments not being skipped properly, and errors for magic methods on enums ( ref #205 )

the `use` parser is currently broken, and is only able to handle basic use statements, we would need to refactor it.

