### PR TITLE
feat: introduce token stream

### DIFF
--- a/bin/snapshot.rs
+++ b/bin/snapshot.rs
@@ -45,7 +45,7 @@ fn main() {
 
         match tokens {
             Ok(tokens) => {
-                let ast = parse(tokens);
+                let ast = parse(&tokens);
                 match ast {
                     Ok(ast) => {
                         std::fs::write(ast_filename, format!("{:#?}\n", ast)).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> ParseResult<()> {
     let tokens = lexer.tokenize(&contents)?;
     dbg!(&tokens);
 
-    let ast = php_parser_rs::parse(tokens)?;
+    let ast = php_parser_rs::parse(&tokens)?;
 
     dbg!(ast);
 

--- a/src/parser/internal/attributes.rs
+++ b/src/parser/internal/attributes.rs
@@ -7,21 +7,19 @@ use crate::parser::internal::utils;
 use crate::parser::state::State;
 
 pub fn gather_attributes(state: &mut State) -> ParseResult<bool> {
-    state.gather_comments();
-
-    if state.current.kind != TokenKind::Attribute {
+    if state.stream.current().kind != TokenKind::Attribute {
         return Ok(false);
     }
 
-    let start = state.current.span;
+    let start = state.stream.current().span;
     let mut members = vec![];
 
-    state.next();
+    state.stream.next();
 
-    while state.current.kind != TokenKind::RightBracket {
-        let start = state.current.span;
+    while state.stream.current().kind != TokenKind::RightBracket {
+        let start = state.stream.current().span;
         let expression = expressions::lowest_precedence(state)?;
-        let end = state.current.span;
+        let end = state.stream.current().span;
 
         members.push(Attribute {
             start,
@@ -29,8 +27,8 @@ pub fn gather_attributes(state: &mut State) -> ParseResult<bool> {
             end,
         });
 
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }

--- a/src/parser/internal/blocks.rs
+++ b/src/parser/internal/blocks.rs
@@ -17,18 +17,15 @@ pub fn block_statement(state: &mut State) -> ParseResult<Statement> {
 }
 
 pub fn body(state: &mut State, until: &TokenKind) -> ParseResult<Block> {
-    state.skip_comments();
-
     let mut block = Block::new();
 
-    while !state.is_eof() && &state.current.kind != until {
-        if let TokenKind::OpenTag(_) = state.current.kind {
-            state.next();
+    while !state.stream.is_eof() && &state.stream.current().kind != until {
+        if let TokenKind::OpenTag(_) = state.stream.current().kind {
+            state.stream.next();
             continue;
         }
 
         block.push(parser::statement(state)?);
-        state.skip_comments();
     }
 
     Ok(block)

--- a/src/parser/internal/constants.rs
+++ b/src/parser/internal/constants.rs
@@ -23,10 +23,8 @@ pub fn parse(state: &mut State) -> ParseResult<Constant> {
 
         entries.push(ConstantEntry { name, value });
 
-        state.skip_comments();
-
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }
@@ -60,10 +58,8 @@ pub fn classish(
 
         entries.push(ConstantEntry { name, value });
 
-        state.skip_comments();
-
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }

--- a/src/parser/internal/interfaces.rs
+++ b/src/parser/internal/interfaces.rs
@@ -26,10 +26,10 @@ pub fn parse(state: &mut State) -> ParseResult<Statement> {
 
     let name = identifiers::type_identifier(state)?;
 
-    let extends = if state.current.kind == TokenKind::Extends {
-        let span = state.current.span;
+    let extends = if state.stream.current().kind == TokenKind::Extends {
+        let span = state.stream.current().span;
 
-        state.next();
+        state.stream.next();
 
         let parents = utils::at_least_one_comma_separated::<SimpleIdentifier>(state, &|state| {
             identifiers::full_type_name(state)
@@ -46,8 +46,7 @@ pub fn parse(state: &mut State) -> ParseResult<Statement> {
         utils::skip_left_brace(state)?;
 
         let mut members = Vec::new();
-        while state.current.kind != TokenKind::RightBrace {
-            state.skip_comments();
+        while state.stream.current().kind != TokenKind::RightBrace {
             members.push(member(state)?);
         }
 
@@ -69,7 +68,7 @@ fn member(state: &mut State) -> ParseResult<InterfaceMember> {
 
     let modifiers = modifiers::collect(state)?;
 
-    if state.current.kind == TokenKind::Const {
+    if state.stream.current().kind == TokenKind::Const {
         constants::classish(state, constant_modifiers(modifiers)?).map(InterfaceMember::Constant)
     } else {
         method(state, method_modifiers(modifiers)?).map(InterfaceMember::Method)

--- a/src/parser/internal/loops.rs
+++ b/src/parser/internal/loops.rs
@@ -16,22 +16,22 @@ pub fn foreach_loop(state: &mut State) -> ParseResult<Statement> {
 
     utils::skip(state, TokenKind::As)?;
 
-    let mut by_ref = state.current.kind == TokenKind::Ampersand;
+    let mut by_ref = state.stream.current().kind == TokenKind::Ampersand;
     if by_ref {
-        state.next();
+        state.stream.next();
     }
 
     let mut key_var = None;
     let mut value_var = expressions::lowest_precedence(state)?;
 
-    if state.current.kind == TokenKind::DoubleArrow {
-        state.next();
+    if state.stream.current().kind == TokenKind::DoubleArrow {
+        state.stream.next();
 
         key_var = Some(value_var.clone());
 
-        by_ref = state.current.kind == TokenKind::Ampersand;
+        by_ref = state.stream.current().kind == TokenKind::Ampersand;
         if by_ref {
-            state.next();
+            state.stream.next();
         }
 
         value_var = expressions::lowest_precedence(state)?;
@@ -39,13 +39,13 @@ pub fn foreach_loop(state: &mut State) -> ParseResult<Statement> {
 
     utils::skip_right_parenthesis(state)?;
 
-    let body = if state.current.kind == TokenKind::Colon {
+    let body = if state.stream.current().kind == TokenKind::Colon {
         utils::skip_colon(state)?;
         let then = blocks::body(state, &TokenKind::EndForeach)?;
         utils::skip(state, TokenKind::EndForeach)?;
         utils::skip_semicolon(state)?;
         then
-    } else if state.current.kind == TokenKind::LeftBrace {
+    } else if state.stream.current().kind == TokenKind::LeftBrace {
         utils::skip_left_brace(state)?;
         let then = blocks::body(state, &TokenKind::RightBrace)?;
         utils::skip_right_brace(state)?;
@@ -70,14 +70,14 @@ pub fn for_loop(state: &mut State) -> ParseResult<Statement> {
 
     let mut init = Vec::new();
     loop {
-        if state.current.kind == TokenKind::SemiColon {
+        if state.stream.current().kind == TokenKind::SemiColon {
             break;
         }
 
         init.push(expressions::lowest_precedence(state)?);
 
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }
@@ -87,14 +87,14 @@ pub fn for_loop(state: &mut State) -> ParseResult<Statement> {
 
     let mut condition = Vec::new();
     loop {
-        if state.current.kind == TokenKind::SemiColon {
+        if state.stream.current().kind == TokenKind::SemiColon {
             break;
         }
 
         condition.push(expressions::lowest_precedence(state)?);
 
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }
@@ -103,14 +103,14 @@ pub fn for_loop(state: &mut State) -> ParseResult<Statement> {
 
     let mut r#loop = Vec::new();
     loop {
-        if state.current.kind == TokenKind::RightParen {
+        if state.stream.current().kind == TokenKind::RightParen {
             break;
         }
 
         r#loop.push(expressions::lowest_precedence(state)?);
 
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }
@@ -118,13 +118,13 @@ pub fn for_loop(state: &mut State) -> ParseResult<Statement> {
 
     utils::skip_right_parenthesis(state)?;
 
-    let then = if state.current.kind == TokenKind::Colon {
+    let then = if state.stream.current().kind == TokenKind::Colon {
         utils::skip_colon(state)?;
         let then = blocks::body(state, &TokenKind::EndFor)?;
         utils::skip(state, TokenKind::EndFor)?;
         utils::skip_semicolon(state)?;
         then
-    } else if state.current.kind == TokenKind::LeftBrace {
+    } else if state.stream.current().kind == TokenKind::LeftBrace {
         utils::skip_left_brace(state)?;
         let then = blocks::body(state, &TokenKind::RightBrace)?;
         utils::skip_right_brace(state)?;
@@ -144,7 +144,7 @@ pub fn for_loop(state: &mut State) -> ParseResult<Statement> {
 pub fn do_loop(state: &mut State) -> ParseResult<Statement> {
     utils::skip(state, TokenKind::Do)?;
 
-    let body = if state.current.kind == TokenKind::LeftBrace {
+    let body = if state.stream.current().kind == TokenKind::LeftBrace {
         utils::skip_left_brace(state)?;
         let body = blocks::body(state, &TokenKind::RightBrace)?;
         utils::skip_right_brace(state)?;
@@ -172,16 +172,16 @@ pub fn while_loop(state: &mut State) -> ParseResult<Statement> {
 
     utils::skip_right_parenthesis(state)?;
 
-    let body = if state.current.kind == TokenKind::SemiColon {
+    let body = if state.stream.current().kind == TokenKind::SemiColon {
         utils::skip_semicolon(state)?;
         vec![]
-    } else if state.current.kind == TokenKind::Colon {
+    } else if state.stream.current().kind == TokenKind::Colon {
         utils::skip_colon(state)?;
         let then = blocks::body(state, &TokenKind::EndWhile)?;
         utils::skip(state, TokenKind::EndWhile)?;
         utils::skip_semicolon(state)?;
         then
-    } else if state.current.kind == TokenKind::LeftBrace {
+    } else if state.stream.current().kind == TokenKind::LeftBrace {
         utils::skip_left_brace(state)?;
         let then = blocks::body(state, &TokenKind::RightBrace)?;
         utils::skip_right_brace(state)?;
@@ -197,7 +197,7 @@ pub fn continue_statement(state: &mut State) -> ParseResult<Statement> {
     utils::skip(state, TokenKind::Continue)?;
 
     let mut num = None;
-    if state.current.kind != TokenKind::SemiColon {
+    if state.stream.current().kind != TokenKind::SemiColon {
         num = Some(expressions::lowest_precedence(state)?);
     }
 
@@ -210,7 +210,7 @@ pub fn break_statement(state: &mut State) -> ParseResult<Statement> {
     utils::skip(state, TokenKind::Break)?;
 
     let mut num = None;
-    if state.current.kind != TokenKind::SemiColon {
+    if state.stream.current().kind != TokenKind::SemiColon {
         num = Some(expressions::lowest_precedence(state)?);
     }
 

--- a/src/parser/internal/modifiers.rs
+++ b/src/parser/internal/modifiers.rs
@@ -273,44 +273,50 @@ pub fn collect(state: &mut State) -> ParseResult<Vec<(Span, TokenKind, Span)>> {
     | TokenKind::Final
     | TokenKind::Abstract
     | TokenKind::Static
-    | TokenKind::Readonly = state.current.kind.clone()
+    | TokenKind::Readonly = state.stream.current().kind.clone()
     {
-        if collected_tokens.contains(&state.current.kind) {
+        if collected_tokens.contains(&state.stream.current().kind) {
             return Err(ParseError::MultipleModifiers(
-                state.current.kind.to_string(),
-                state.current.span,
+                state.stream.current().kind.to_string(),
+                state.stream.current().span,
             ));
         }
 
         // garud against multiple visibility modifiers, we don't care where these modifiers are used.
-        match state.current.kind {
+        match state.stream.current().kind {
             TokenKind::Private
                 if collected_tokens.contains(&TokenKind::Protected)
                     || collected_tokens.contains(&TokenKind::Public) =>
             {
-                return Err(ParseError::MultipleVisibilityModifiers(state.current.span));
+                return Err(ParseError::MultipleVisibilityModifiers(
+                    state.stream.current().span,
+                ));
             }
             TokenKind::Protected
                 if collected_tokens.contains(&TokenKind::Private)
                     || collected_tokens.contains(&TokenKind::Public) =>
             {
-                return Err(ParseError::MultipleVisibilityModifiers(state.current.span));
+                return Err(ParseError::MultipleVisibilityModifiers(
+                    state.stream.current().span,
+                ));
             }
             TokenKind::Public
                 if collected_tokens.contains(&TokenKind::Private)
                     || collected_tokens.contains(&TokenKind::Protected) =>
             {
-                return Err(ParseError::MultipleVisibilityModifiers(state.current.span));
+                return Err(ParseError::MultipleVisibilityModifiers(
+                    state.stream.current().span,
+                ));
             }
             _ => {}
         };
 
-        let start = state.current.span;
-        let end = state.peek.span;
-        collected.push((start, state.current.kind.clone(), end));
-        collected_tokens.push(state.current.kind.clone());
+        let start = state.stream.current().span;
+        let end = state.stream.peek().span;
+        collected.push((start, state.stream.current().kind.clone(), end));
+        collected_tokens.push(state.stream.current().kind.clone());
 
-        state.next();
+        state.stream.next();
     }
 
     Ok(collected)

--- a/src/parser/internal/namespaces.rs
+++ b/src/parser/internal/namespaces.rs
@@ -13,15 +13,15 @@ use crate::parser::state::State;
 use crate::scoped;
 
 pub fn namespace(state: &mut State) -> ParseResult<Statement> {
-    state.next();
+    state.stream.next();
 
     let name = identifiers::optional_name(state);
 
     if let Some(name) = &name {
-        if state.current.kind != TokenKind::LeftBrace {
+        if state.stream.current().kind != TokenKind::LeftBrace {
             if let Some(NamespaceType::Braced) = state.namespace_type() {
                 return Err(ParseError::MixingBracedAndUnBracedNamespaceDeclarations(
-                    state.current.span,
+                    state.stream.current().span,
                 ));
             }
 
@@ -31,11 +31,11 @@ pub fn namespace(state: &mut State) -> ParseResult<Statement> {
 
     match state.namespace_type() {
         Some(NamespaceType::Unbraced) => Err(
-            ParseError::MixingBracedAndUnBracedNamespaceDeclarations(state.current.span),
+            ParseError::MixingBracedAndUnBracedNamespaceDeclarations(state.stream.current().span),
         ),
-        Some(NamespaceType::Braced) if state.namespace().is_some() => {
-            Err(ParseError::NestedNamespaceDeclarations(state.current.span))
-        }
+        Some(NamespaceType::Braced) if state.namespace().is_some() => Err(
+            ParseError::NestedNamespaceDeclarations(state.stream.current().span),
+        ),
         _ => braced_namespace(state, name),
     }
 }
@@ -46,7 +46,7 @@ fn unbraced_namespace(state: &mut State, name: SimpleIdentifier) -> ParseResult<
         // since this is an unbraced namespace, as soon as we encouter another
         // `namespace` token as a top level statement, this namespace scope ends.
         // otherwise we will end up with nested namespace statements.
-        while state.current.kind != TokenKind::Namespace && !state.is_eof() {
+        while state.stream.current().kind != TokenKind::Namespace && !state.stream.is_eof() {
             body.push(parser::top_level_statement(state)?);
         }
 
@@ -61,7 +61,7 @@ fn braced_namespace(state: &mut State, name: Option<SimpleIdentifier>) -> ParseR
 
     let body = scoped!(state, Scope::BracedNamespace(name.clone()), {
         let mut body = Block::new();
-        while state.current.kind != TokenKind::RightBrace && !state.is_eof() {
+        while state.stream.current().kind != TokenKind::RightBrace && !state.stream.is_eof() {
             body.push(parser::top_level_statement(state)?);
         }
 

--- a/src/parser/internal/properties.rs
+++ b/src/parser/internal/properties.rs
@@ -23,8 +23,8 @@ pub fn parse(
     loop {
         let variable = variables::simple_variable(state)?;
         let mut value = None;
-        if state.current.kind == TokenKind::Equals {
-            state.next();
+        if state.stream.current().kind == TokenKind::Equals {
+            state.stream.next();
             value = Some(expressions::lowest_precedence(state)?);
         }
 
@@ -33,7 +33,7 @@ pub fn parse(
                 return Err(ParseError::StaticPropertyUsingReadonlyModifier(
                     class,
                     variable.to_string(),
-                    state.current.span,
+                    state.stream.current().span,
                 ));
             }
 
@@ -41,7 +41,7 @@ pub fn parse(
                 return Err(ParseError::ReadonlyPropertyHasDefaultValue(
                     class,
                     variable.to_string(),
-                    state.current.span,
+                    state.stream.current().span,
                 ));
             }
         }
@@ -53,7 +53,7 @@ pub fn parse(
                         class,
                         variable.to_string(),
                         ty.clone(),
-                        state.current.span,
+                        state.stream.current().span,
                     ));
                 }
             }
@@ -62,7 +62,7 @@ pub fn parse(
                     return Err(ParseError::MissingTypeForReadonlyProperty(
                         class,
                         variable.to_string(),
-                        state.current.span,
+                        state.stream.current().span,
                     ));
                 }
             }
@@ -70,10 +70,8 @@ pub fn parse(
 
         entries.push(PropertyEntry { variable, value });
 
-        state.skip_comments();
-
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }
@@ -98,8 +96,8 @@ pub fn parse_var(state: &mut State, class: String) -> ParseResult<VariableProper
     loop {
         let variable = variables::simple_variable(state)?;
         let mut value = None;
-        if state.current.kind == TokenKind::Equals {
-            state.next();
+        if state.stream.current().kind == TokenKind::Equals {
+            state.stream.next();
             value = Some(expressions::lowest_precedence(state)?);
         }
 
@@ -109,17 +107,15 @@ pub fn parse_var(state: &mut State, class: String) -> ParseResult<VariableProper
                     class,
                     variable.to_string(),
                     ty.clone(),
-                    state.current.span,
+                    state.stream.current().span,
                 ));
             }
         }
 
         entries.push(VariablePropertyEntry { variable, value });
 
-        state.skip_comments();
-
-        if state.current.kind == TokenKind::Comma {
-            state.next();
+        if state.stream.current().kind == TokenKind::Comma {
+            state.stream.next();
         } else {
             break;
         }

--- a/src/parser/internal/variables.rs
+++ b/src/parser/internal/variables.rs
@@ -10,9 +10,9 @@ use crate::parser::internal::utils;
 use crate::parser::state::State;
 
 pub fn simple_variable(state: &mut State) -> ParseResult<SimpleVariable> {
-    if let TokenKind::Variable(name) = state.current.kind.clone() {
-        let span = state.current.span;
-        state.next();
+    if let TokenKind::Variable(name) = state.stream.current().kind.clone() {
+        let span = state.stream.current().span;
+        state.stream.next();
 
         return Ok(SimpleVariable { span, name });
     }
@@ -21,16 +21,16 @@ pub fn simple_variable(state: &mut State) -> ParseResult<SimpleVariable> {
 }
 
 pub fn dynamic_variable(state: &mut State) -> ParseResult<Variable> {
-    match state.current.kind.clone() {
+    match state.stream.current().kind.clone() {
         TokenKind::Variable(name) => {
-            let span = state.current.span;
-            state.next();
+            let span = state.stream.current().span;
+            state.stream.next();
 
             Ok(Variable::SimpleVariable(SimpleVariable { span, name }))
         }
         TokenKind::DollarLeftBrace => {
-            let start = state.current.span;
-            state.next();
+            let start = state.stream.current().span;
+            state.stream.next();
 
             let expr = expressions::lowest_precedence(state)?;
 
@@ -43,10 +43,10 @@ pub fn dynamic_variable(state: &mut State) -> ParseResult<Variable> {
             }))
         }
         // todo(azjezz): figure out why the lexer does this.
-        TokenKind::Dollar if state.peek.kind == TokenKind::LeftBrace => {
-            let start = state.current.span;
-            state.next();
-            state.next();
+        TokenKind::Dollar if state.stream.peek().kind == TokenKind::LeftBrace => {
+            let start = state.stream.current().span;
+            state.stream.next();
+            state.stream.next();
 
             let expr = expressions::lowest_precedence(state)?;
 
@@ -59,8 +59,8 @@ pub fn dynamic_variable(state: &mut State) -> ParseResult<Variable> {
             }))
         }
         TokenKind::Dollar => {
-            let span = state.current.span;
-            state.next();
+            let span = state.stream.current().span;
+            state.stream.next();
 
             let variable = dynamic_variable(state)?;
 

--- a/src/parser/stream.rs
+++ b/src/parser/stream.rs
@@ -1,0 +1,211 @@
+use crate::lexer::token::Token;
+use crate::lexer::token::TokenKind;
+
+/// Token stream.
+///
+/// # Examples
+///
+/// ```rust
+/// use php_parser_rs::lexer::token::Token;
+/// use php_parser_rs::lexer::token::TokenKind;
+/// use php_parser_rs::lexer::stream::TokenStream;
+///
+/// let tokens = vec![
+///     Token { kind: TokenKind::SingleLineComment("// some class".into()), span: (1, 1) },
+///     Token { kind: TokenKind::Readonly, span: (2, 1) },
+///     Token { kind: TokenKind::Class, span: (2, 10) },
+///     Token { kind: TokenKind::Enum, span: (2, 16) },
+///     Token { kind: TokenKind::LeftBrace, span: (2, 21) },
+///     Token { kind: TokenKind::SingleLineComment("// empty body!".into()), span: (3, 1) },
+///     Token { kind: TokenKind::RightBrace, span: (4, 1) },
+///     Token { kind: TokenKind::Eof, span: (0, 0) },
+/// ];
+///
+/// let mut stream = TokenStream::new(tokens);
+///
+/// assert!(matches!(stream.current().kind, TokenKind::Readonly));
+/// assert!(matches!(stream.peek().kind, TokenKind::Class));
+/// assert!(matches!(stream.lookahead(1).kind, TokenKind::Enum));
+/// assert!(matches!(stream.lookahead(2).kind, TokenKind::LeftBrace));
+/// assert!(matches!(stream.lookahead(3).kind, TokenKind::RightBrace));
+/// assert!(matches!(stream.lookahead(4).kind, TokenKind::Eof));
+/// assert!(matches!(stream.lookahead(5).kind, TokenKind::Eof));
+///
+/// stream.next();
+///
+/// assert!(matches!(stream.current().kind, TokenKind::Class));
+///
+/// stream.next();
+/// stream.next();
+/// stream.next();
+///
+/// assert!(matches!(stream.current().kind, TokenKind::RightBrace));
+///
+/// stream.next();
+///
+/// assert!(matches!(stream.current().kind, TokenKind::Eof));
+/// assert!(stream.is_eof());
+///
+/// assert_eq!(stream.comments(), vec![
+///     Token { kind: TokenKind::SingleLineComment("// some class".into()), span: (1, 1) },
+///     Token { kind: TokenKind::SingleLineComment("// empty body!".into()), span: (3, 1) },
+/// ]);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenStream<'a> {
+    tokens: &'a [Token],
+    length: usize,
+    comments: Vec<Token>,
+    cursor: usize,
+    default: Token,
+}
+
+/// Token stream.
+impl<'a> TokenStream<'a> {
+    pub fn new(tokens: &'a [Token]) -> TokenStream {
+        let length = tokens.len();
+
+        let mut stream = TokenStream {
+            tokens,
+            length,
+            comments: vec![],
+            cursor: 0,
+            default: Token::default(),
+        };
+
+        stream.collect_comments();
+
+        stream
+    }
+
+    /// Move cursor to next token.
+    ///
+    /// Comments are collected.
+    pub fn next(&mut self) {
+        self.cursor += 1;
+        self.collect_comments();
+    }
+
+    /// Get current token.
+    pub fn current(&self) -> &Token {
+        let mut cursor = self.cursor;
+        loop {
+            if cursor >= self.length {
+                return &self.default;
+            }
+
+            let current = &self.tokens[cursor];
+
+            if matches!(
+                current.kind,
+                TokenKind::SingleLineComment(_)
+                    | TokenKind::MultiLineComment(_)
+                    | TokenKind::HashMarkComment(_)
+                    | TokenKind::DocumentComment(_)
+            ) {
+                cursor += 1;
+                continue;
+            }
+
+            return current;
+        }
+    }
+
+    /// Peek next token.
+    ///
+    /// All comments are skipped.
+    pub fn peek(&self) -> &Token {
+        self.peek_nth(1)
+    }
+
+    /// Peek nth+1 token.
+    ///
+    /// All comments are skipped.
+    pub fn lookahead(&self, n: usize) -> &Token {
+        self.peek_nth(n + 1)
+    }
+
+    /// Peek nth token.
+    ///
+    /// All comments are skipped.
+    #[inline(always)]
+    fn peek_nth(&self, n: usize) -> &Token {
+        let mut cursor = self.cursor;
+        let mut target = 0;
+        loop {
+            if cursor >= self.length {
+                return &self.default;
+            }
+
+            let current = &self.tokens[cursor];
+
+            if matches!(
+                current.kind,
+                TokenKind::SingleLineComment(_)
+                    | TokenKind::MultiLineComment(_)
+                    | TokenKind::HashMarkComment(_)
+                    | TokenKind::DocumentComment(_)
+            ) {
+                cursor += 1;
+                continue;
+            }
+
+            if target == n {
+                return current;
+            }
+
+            target += 1;
+            cursor += 1;
+        }
+    }
+
+    /// Check if current token is EOF.
+    pub fn is_eof(&self) -> bool {
+        self.current().kind == TokenKind::Eof
+    }
+
+    /// Get all comments.
+    #[allow(dead_code)]
+    pub fn comments(&mut self) -> Vec<Token> {
+        let mut comments = vec![];
+
+        std::mem::swap(&mut self.comments, &mut comments);
+
+        comments
+    }
+
+    fn collect_comments(&mut self) {
+        loop {
+            if self.cursor >= self.length {
+                break;
+            }
+
+            let current = &self.tokens[self.cursor];
+
+            if !matches!(
+                current.kind,
+                TokenKind::SingleLineComment(_)
+                    | TokenKind::MultiLineComment(_)
+                    | TokenKind::HashMarkComment(_)
+                    | TokenKind::DocumentComment(_)
+            ) {
+                break;
+            }
+
+            self.comments.push(current.clone());
+            self.cursor += 1;
+        }
+    }
+}
+
+impl<'a> Default for TokenStream<'a> {
+    fn default() -> Self {
+        Self::new(&[])
+    }
+}
+
+impl<'a> From<&'a Vec<Token>> for TokenStream<'a> {
+    fn from(tokens: &'a Vec<Token>) -> Self {
+        Self::new(tokens.as_slice())
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,7 +54,7 @@ fn test_fixtures() {
 
         if ast_file.exists() {
             let expected_ast = std::fs::read_to_string(&ast_file).unwrap();
-            let ast = php_parser_rs::parse(tokens).unwrap();
+            let ast = php_parser_rs::parse(&tokens).unwrap();
             assert_str_eq!(
                 expected_ast.trim(),
                 format!("{:#?}", ast),
@@ -72,7 +72,7 @@ fn test_fixtures() {
         );
 
         let expected_error = std::fs::read_to_string(&parse_err_file).unwrap();
-        let error = php_parser_rs::parse(tokens).err().unwrap();
+        let error = php_parser_rs::parse(&tokens).err().unwrap();
 
         assert_str_eq!(
             expected_error.trim(),

--- a/tests/third_party_tests.rs
+++ b/tests/third_party_tests.rs
@@ -365,7 +365,7 @@ fn test_repository(name: &str, repository: &str, ignore: &[&str]) {
                 let code = std::fs::read(&filename).unwrap();
 
                 match Lexer::new().tokenize(&code) {
-                    Ok(tokens) => match php_parser_rs::parse(tokens) {
+                    Ok(tokens) => match php_parser_rs::parse(&tokens) {
                         Ok(_) => {
                             results.push(TestResult::Success);
                         }


### PR DESCRIPTION
this token stream allows us not to worry about comments, instead just focus on relevant tokens, comments are always collected, in a future PR, i plan to:

1. change `TokenStream::comments()` to return `CommentGroup` node
2. attach `CommentGroup` node to every node, starting with types, functions, ..etc, so that we can support doc blocks.

