### PR TITLE
parser: support die/exit expressions

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1601,6 +1601,8 @@ fn parse_int(buffer: &[u8]) -> SyntaxResult<TokenKind> {
 
 fn identifier_to_keyword(ident: &[u8]) -> Option<TokenKind> {
     Some(match ident.to_ascii_lowercase().as_slice() {
+        b"die" => TokenKind::Die,
+        b"exit" => TokenKind::Exit,
         b"enddeclare" => TokenKind::EndDeclare,
         b"endswitch" => TokenKind::EndSwitch,
         b"endfor" => TokenKind::EndFor,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -43,6 +43,7 @@ impl From<DocStringIndentationKind> for u8 {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 pub enum TokenKind {
+    Die,
     // Can't use `Self` as a name here, so suffixing with an underscore.
     Self_,
     Parent,
@@ -250,6 +251,7 @@ impl Default for Token {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
+            Self::Die => "die",
             Self::Self_ => "self",
             Self::Parent => "parent",
             Self::Backtick => "`",

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -340,6 +340,12 @@ pub struct Use {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
+    Die {
+        value: Option<Box<Expression>>,
+    },
+    Exit {
+        value: Option<Box<Expression>>,
+    },
     ArithmeticOperation(ArithmeticOperation),
     AssignmentOperation(AssignmentOperation),
     BitwiseOperation(BitwiseOperation),

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -549,9 +549,51 @@ expressions! {
         functions::arrow_function(state)
     })
 
-    #[before(reserved_identifier_function_call), current(TokenKind::Function)]
+    #[before(die), current(TokenKind::Function)]
     anonymous_function(|state: &mut State| {
         functions::anonymous_function(state)
+    })
+
+    #[before(exit), current(TokenKind::Die)]
+    die(|state: &mut State| {
+        state.stream.next();
+        let value = if state.stream.current().kind == TokenKind::LeftParen {
+            state.stream.next();
+
+            if state.stream.current().kind != TokenKind::RightParen {
+                let value = Some(Box::new(lowest_precedence(state)?));
+                utils::skip_right_parenthesis(state)?;
+                value
+            } else {
+                utils::skip_right_parenthesis(state)?;
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(Expression::Die { value })
+    })
+
+    #[before(reserved_identifier_function_call), current(TokenKind::Exit)]
+    exit(|state: &mut State| {
+        state.stream.next();
+        let value = if state.stream.current().kind == TokenKind::LeftParen {
+            state.stream.next();
+
+            if state.stream.current().kind != TokenKind::RightParen {
+                let value = Some(Box::new(lowest_precedence(state)?));
+                utils::skip_right_parenthesis(state)?;
+                value
+            } else {
+                utils::skip_right_parenthesis(state)?;
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(Expression::Exit { value })
     })
 
     #[before(reserved_identifier_static_call), current(

--- a/src/parser/internal/identifiers.rs
+++ b/src/parser/internal/identifiers.rs
@@ -296,6 +296,7 @@ pub fn is_reserved_identifier(kind: &TokenKind) -> bool {
             | TokenKind::New
             | TokenKind::Clone
             | TokenKind::Exit
+            | TokenKind::Die
             | TokenKind::If
             | TokenKind::ElseIf
             | TokenKind::Else

--- a/tests/fixtures/0001/ast.txt
+++ b/tests/fixtures/0001/ast.txt
@@ -91,27 +91,12 @@
             by_ref: false,
             body: [
                 Expression {
-                    expr: Call {
-                        target: Identifier(
-                            SimpleIdentifier(
-                                SimpleIdentifier {
-                                    span: (
-                                        4,
-                                        5,
-                                    ),
-                                    name: "exit",
-                                },
-                            ),
-                        ),
-                        args: [
-                            Arg {
-                                name: None,
-                                value: LiteralInteger {
-                                    i: "1",
-                                },
-                                unpack: false,
+                    expr: Exit {
+                        value: Some(
+                            LiteralInteger {
+                                i: "1",
                             },
-                        ],
+                        ),
                     },
                 },
             ],

--- a/tests/fixtures/0215/ast.txt
+++ b/tests/fixtures/0215/ast.txt
@@ -50,27 +50,12 @@
                         body: Some(
                             [
                                 Expression {
-                                    expr: Call {
-                                        target: Identifier(
-                                            SimpleIdentifier(
-                                                SimpleIdentifier {
-                                                    span: (
-                                                        8,
-                                                        9,
-                                                    ),
-                                                    name: "exit",
-                                                },
-                                            ),
-                                        ),
-                                        args: [
-                                            Arg {
-                                                name: None,
-                                                value: LiteralInteger {
-                                                    i: "1",
-                                                },
-                                                unpack: false,
+                                    expr: Exit {
+                                        value: Some(
+                                            LiteralInteger {
+                                                i: "1",
                                             },
-                                        ],
+                                        ),
                                     },
                                 },
                             ],

--- a/tests/fixtures/0216/ast.txt
+++ b/tests/fixtures/0216/ast.txt
@@ -52,27 +52,12 @@
                         body: Some(
                             [
                                 Expression {
-                                    expr: Call {
-                                        target: Identifier(
-                                            SimpleIdentifier(
-                                                SimpleIdentifier {
-                                                    span: (
-                                                        5,
-                                                        9,
-                                                    ),
-                                                    name: "exit",
-                                                },
-                                            ),
-                                        ),
-                                        args: [
-                                            Arg {
-                                                name: None,
-                                                value: LiteralInteger {
-                                                    i: "1",
-                                                },
-                                                unpack: false,
+                                    expr: Exit {
+                                        value: Some(
+                                            LiteralInteger {
+                                                i: "1",
                                             },
-                                        ],
+                                        ),
                                     },
                                 },
                             ],

--- a/tests/fixtures/0218/ast.txt
+++ b/tests/fixtures/0218/ast.txt
@@ -64,27 +64,12 @@
                                         body: Some(
                                             [
                                                 Expression {
-                                                    expr: Call {
-                                                        target: Identifier(
-                                                            SimpleIdentifier(
-                                                                SimpleIdentifier {
-                                                                    span: (
-                                                                        5,
-                                                                        9,
-                                                                    ),
-                                                                    name: "exit",
-                                                                },
-                                                            ),
-                                                        ),
-                                                        args: [
-                                                            Arg {
-                                                                name: None,
-                                                                value: LiteralInteger {
-                                                                    i: "1",
-                                                                },
-                                                                unpack: false,
+                                                    expr: Exit {
+                                                        value: Some(
+                                                            LiteralInteger {
+                                                                i: "1",
                                                             },
-                                                        ],
+                                                        ),
                                                     },
                                                 },
                                             ],

--- a/tests/fixtures/0219/ast.txt
+++ b/tests/fixtures/0219/ast.txt
@@ -51,27 +51,12 @@
                         body: Some(
                             [
                                 Expression {
-                                    expr: Call {
-                                        target: Identifier(
-                                            SimpleIdentifier(
-                                                SimpleIdentifier {
-                                                    span: (
-                                                        5,
-                                                        9,
-                                                    ),
-                                                    name: "exit",
-                                                },
-                                            ),
-                                        ),
-                                        args: [
-                                            Arg {
-                                                name: None,
-                                                value: LiteralInteger {
-                                                    i: "1",
-                                                },
-                                                unpack: false,
+                                    expr: Exit {
+                                        value: Some(
+                                            LiteralInteger {
+                                                i: "1",
                                             },
-                                        ],
+                                        ),
                                     },
                                 },
                             ],

--- a/tests/fixtures/0221/ast.txt
+++ b/tests/fixtures/0221/ast.txt
@@ -233,27 +233,12 @@
             by_ref: false,
             body: [
                 Expression {
-                    expr: Call {
-                        target: Identifier(
-                            SimpleIdentifier(
-                                SimpleIdentifier {
-                                    span: (
-                                        9,
-                                        5,
-                                    ),
-                                    name: "exit",
-                                },
-                            ),
-                        ),
-                        args: [
-                            Arg {
-                                name: None,
-                                value: LiteralInteger {
-                                    i: "0",
-                                },
-                                unpack: false,
+                    expr: Exit {
+                        value: Some(
+                            LiteralInteger {
+                                i: "0",
                             },
-                        ],
+                        ),
                     },
                 },
             ],


### PR DESCRIPTION
We didn't actually parse these correctly, they would be parsed as identifiers / call expressions depending on usage.