### PR TITLE
chore: improve performance for token stream

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -41,7 +41,7 @@ pub fn parse(tokens: &[Token]) -> ParseResult<Program> {
 
     let mut ast = Program::new();
 
-    while state.stream.current().kind != TokenKind::Eof {
+    while !state.stream.is_eof() {
         if matches!(
             state.stream.current().kind,
             TokenKind::OpenTag(_) | TokenKind::CloseTag

--- a/src/parser/stream.rs
+++ b/src/parser/stream.rs
@@ -87,41 +87,25 @@ impl<'a> TokenStream<'a> {
     }
 
     /// Get current token.
-    pub fn current(&self) -> &Token {
-        let mut cursor = self.cursor;
-        loop {
-            if cursor >= self.length {
-                return &self.default;
-            }
-
-            let current = &self.tokens[cursor];
-
-            if matches!(
-                current.kind,
-                TokenKind::SingleLineComment(_)
-                    | TokenKind::MultiLineComment(_)
-                    | TokenKind::HashMarkComment(_)
-                    | TokenKind::DocumentComment(_)
-            ) {
-                cursor += 1;
-                continue;
-            }
-
-            return current;
+    pub const fn current(&self) -> &Token {
+        if self.cursor >= self.length {
+            return &self.default;
         }
+
+        &self.tokens[self.cursor]
     }
 
     /// Peek next token.
     ///
     /// All comments are skipped.
-    pub fn peek(&self) -> &Token {
+    pub const fn peek(&self) -> &Token {
         self.peek_nth(1)
     }
 
     /// Peek nth+1 token.
     ///
     /// All comments are skipped.
-    pub fn lookahead(&self, n: usize) -> &Token {
+    pub const fn lookahead(&self, n: usize) -> &Token {
         self.peek_nth(n + 1)
     }
 
@@ -129,9 +113,9 @@ impl<'a> TokenStream<'a> {
     ///
     /// All comments are skipped.
     #[inline(always)]
-    fn peek_nth(&self, n: usize) -> &Token {
-        let mut cursor = self.cursor;
-        let mut target = 0;
+    const fn peek_nth(&self, n: usize) -> &Token {
+        let mut cursor = self.cursor + 1;
+        let mut target = 1;
         loop {
             if cursor >= self.length {
                 return &self.default;
@@ -161,7 +145,11 @@ impl<'a> TokenStream<'a> {
 
     /// Check if current token is EOF.
     pub fn is_eof(&self) -> bool {
-        self.current().kind == TokenKind::Eof
+        if self.cursor >= self.length {
+            return true;
+        }
+
+        self.tokens[self.cursor].kind == TokenKind::Eof
     }
 
     /// Get all comments.


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/29315886/206932172-8cbbdd75-9827-4974-ba17-57c010406588.png)


after:
![image](https://user-images.githubusercontent.com/29315886/206932154-60ac72dd-190a-4b6c-870e-ef171d828b88.png)


not the best metric to go by, but it shows good improvements :)