### PR TITLE
chore: use `clap` to have command line arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ path = "bin/schema.rs"
 
 [dependencies]
 ariadne = { version = "0.1.5" }
+clap = { version = "4.0.32", features = ["derive"] }
 schemars = { version = "0.8.11" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,25 @@
 use std::io::Result;
+use clap::Parser;
+
+#[derive(Parser,Default,Debug)]
+#[clap(version, about="A PHP Parser")]
+struct Arguments {
+    file: String,
+    #[clap(short, long)]
+    /// Don't print anything
+    silent: bool,
+    #[clap(short, long)]
+    /// Print as json
+    json: bool
+}
 
 fn main() -> Result<()> {
-    let args = std::env::args().collect::<Vec<String>>();
+    let args = Arguments::parse();
 
-    // if --help is passed, or no file is given, print usage in a pretty way and exit
-    if args.contains(&String::from("--help")) || args.len() < 2 {
-        println!("Usage: php-parser-rs [options] <file>");
-        println!("Options:");
-        println!("  --help     Print this help message");
-        println!("  --silent   Don't print anything");
-        println!("  --json     Print as json");
-        std::process::exit(0);
-    }
-
-    // get file from args or print error and exit
-    let file = args.get(1).unwrap();
-    let silent = args.contains(&String::from("--silent"));
-    let print_json = args.contains(&String::from("--json"));
-    let contents = std::fs::read_to_string(file)?;
+    let file = args.file;
+    let contents = std::fs::read_to_string(&file)?;
+    let silent = args.silent;
+    let print_json = args.json;
 
     match php_parser_rs::parse(&contents) {
         Ok(ast) => {
@@ -42,7 +44,7 @@ fn main() -> Result<()> {
             }
         }
         Err(error) => {
-            println!("{}", error.report(&contents, Some(file), true, false)?);
+            println!("{}", error.report(&contents, Some(&file), true, false)?);
 
             std::process::exit(1);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use std::io::Result;
 use clap::Parser;
+use std::io::Result;
 
-#[derive(Parser,Default,Debug)]
-#[clap(version, about="A PHP Parser")]
+#[derive(Parser, Default, Debug)]
+#[clap(version, about = "A PHP Parser")]
 struct Arguments {
     file: String,
     #[clap(short, long)]
@@ -10,7 +10,7 @@ struct Arguments {
     silent: bool,
     #[clap(short, long)]
     /// Print as json
-    json: bool
+    json: bool,
 }
 
 fn main() -> Result<()> {

--- a/tests/third_party_tests.rs
+++ b/tests/third_party_tests.rs
@@ -402,7 +402,7 @@ fn test_repository(name: &str, repository: &str, ignore: &[&str]) {
 
             let mut results = vec![];
             for (name, filename) in entries {
-                let code = std::fs::read(&filename).unwrap();
+                let code = std::fs::read(filename).unwrap();
 
                 match Lexer::new().tokenize(&code) {
                     Ok(tokens) => match php_parser_rs::construct(&tokens) {
@@ -456,7 +456,7 @@ fn read_directory(
     ignore: &[&str],
 ) -> Vec<(String, PathBuf)> {
     let mut results = vec![];
-    let mut entries = fs::read_dir(&directory)
+    let mut entries = fs::read_dir(directory)
         .unwrap()
         .flatten()
         .map(|entry| entry.path())


### PR DESCRIPTION
This PR:

- Let `clap` handle the command line arguments and options

![image](https://user-images.githubusercontent.com/252042/209441307-2789a355-fb2c-4ad1-b278-1010a1cac9e0.png)

I'm pretty new with rust, please let me know if I'm doing something wrong, I'm here to learn :)