### PR TITLE
tests: early ignoring of folders and files

### DIFF
--- a/tests/third_party_tests.rs
+++ b/tests/third_party_tests.rs
@@ -483,8 +483,16 @@ fn read_directory(
             .to_str()
             .unwrap();
 
+        if ignore.contains(path) {
+            continue;
+        }
+
         if name != "php-standard-library" {
-            if let Some(_) = ignored_prefixes.iter().find(|p| path.starts_with(*p)) {
+            if ignored_prefixes
+                .iter()
+                .find(|p| path.starts_with(*p))
+                .is_some()
+            {
                 continue;
             }
         }
@@ -495,7 +503,7 @@ fn read_directory(
             continue;
         }
 
-        if entry.extension().unwrap_or_default() == "php" && !ignore.contains(path) {
+        if entry.extension().unwrap_or_default() == "php" {
             let fullname_string = &entry.to_string_lossy();
             let name = fullname_string
                 .strip_prefix(root.to_str().unwrap())


### PR DESCRIPTION
I was having difficulty ignoring a folder (current logic only ignore files). This change allows me to ignore files or folders by checking if the "path" is included in the ignore list.

Related to the tests being made here: https://github.com/php-rust-tools/parser/issues/250

Ex:

```rust
    test_repository(
        "mezzio-framework",
        "https://github.com/mezzio/mezzio",
        &[
            "vendor/laminas/laminas-validator", // <------ The folder I was ignoring
            // files are Hack, not PHP.
            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/all_options.php",
            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/empty_options.php",
            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/no_options.php",
        ],
    );
```