### PR TITLE
chore: add hyperf to third party tests

### DIFF
--- a/tests/third_party_tests.rs
+++ b/tests/third_party_tests.rs
@@ -33,6 +33,20 @@ fn laravel_framework() {
 }
 
 #[test]
+fn hyperf_framework() {
+    test_repository(
+        "hyperf-framework",
+        "https://github.com/hyperf/hyperf",
+        &[
+            // files are Hack, not PHP.
+            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/all_options.php",
+            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/empty_options.php",
+            "vendor/nikic/fast-route/test/HackTypechecker/fixtures/no_options.php",
+        ],
+    );
+}
+
+#[test]
 fn symfony_framework() {
     test_repository(
         "symfony-framework",


### PR DESCRIPTION
Hyperf is a coroutine framework that runs on top of Swoole. They have dozens of components that do a variety of tasks.

I know that we only need to select some frameworks, the most used ones. Hyperf is one of them, in my opinion.

This is just a suggestion, if we're fine with the ones we already test, feel free to close this PR.